### PR TITLE
[Model] Add declarative API.

### DIFF
--- a/src/Sharpliner.Model/Job.cs
+++ b/src/Sharpliner.Model/Job.cs
@@ -3,20 +3,24 @@ using System.Collections.Generic;
 
 namespace Sharpliner.Model
 {
-    public record Job(
-        string Name,
-        string DisplayName,
-        IEnumerable<string> DependsOn,
-        string Condition,
-        JobStrategy Strategy,
-        JobPool Pool,
-        ContainerReference Container,
-        TimeSpan Timeout,
-        TimeSpan CancelTimeout,
-        IEnumerable<Variable> Variables,
-        IEnumerable<Step> Steps,
-        JobWorkspace Workspace = JobWorkspace.Outputs,
-        bool ContinueOnError = false);
+    public record Job
+    {
+        public string Name { get; init; }
+        public string DisplayName { get; init; }
+        public IEnumerable<string> DependsOn { get; init; }
+        public string Condition { get; init; }
+        public JobStrategy Strategy { get; init; }
+        public JobPool Pool { get; init; }
+        public ContainerReference Container { get; init; }
+        public TimeSpan Timeout { get; init; }
+        public TimeSpan CancelTimeout { get; init; }
+        public Variables Variables  { get; init; }
+        public IEnumerable<Step> Steps { get; init; }
+        public JobWorkspace Workspace { get; init; } = JobWorkspace.Outputs;
+        public bool ContinueOnError { get; init; } = false;
+    }
 
     // TODO: missing properties Uses, Services
+
+    public class Jobs : List<Job> { }
 }

--- a/src/Sharpliner.Model/Sharpliner.Model.csproj
+++ b/src/Sharpliner.Model/Sharpliner.Model.csproj
@@ -6,8 +6,4 @@
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Sharpliner.Model\Sharpliner.Model.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/src/Sharpliner.Model/Stage.cs
+++ b/src/Sharpliner.Model/Stage.cs
@@ -1,12 +1,14 @@
-﻿using System.Collections.Generic;
+﻿using System;
 
 namespace Sharpliner.Model
 {
-    public record Stage(
-        string Name,
-        string DisplayName,
-        IEnumerable<string> DependsOn,
-        string Condition,
-        IEnumerable<Variable> Variables,
-        IEnumerable<Job> Jobs);
+    public record Stage
+    {
+        public string Name { get; init; }
+        public string DisplayName { get; init; }
+        public string[] DependsOn { get; init; } = Array.Empty<string>();
+        public string Condition { get; init; }
+        public Variables Variables { get; init; }
+        public Jobs Jobs { get; init; }
+    }
 }

--- a/src/Sharpliner.Model/Step.cs
+++ b/src/Sharpliner.Model/Step.cs
@@ -1,4 +1,8 @@
-﻿namespace Sharpliner.Model
+﻿using System.Collections.Generic;
+
+namespace Sharpliner.Model
 {
     public abstract record Step();
+    public class Steps : List<Step> { }
+
 }

--- a/src/Sharpliner.Model/Variable.cs
+++ b/src/Sharpliner.Model/Variable.cs
@@ -1,4 +1,6 @@
-﻿namespace Sharpliner.Model
+﻿using System.Collections.Generic;
+
+namespace Sharpliner.Model
 {
     // https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#variables
     public abstract record VariableDefinition;
@@ -33,4 +35,6 @@
         public object Value { get; }
         public bool Readonly { get; }
     }
+
+    public class Variables : List<Variable> {}
 }


### PR DESCRIPTION
This is the first step towards a declarative API to allow to create yaml
pipelines via C#. This new way to write the pipelines allows to declare
a pipeline in the following way:

```csharp
var st = new Stage
{
    Name = "MyName",
    DisplayName = "VisibleName",
    Variables = {
        new ("", ""),
        new ("", "")
    },
    Jobs = {
        new ()
        {
            Name = "First Job",
            DisplayName = "My DisplayName",
            Steps = {
            }
        },
    },
};
```

PS: The collections seem to be a little stupid, but they do allow users not
to need to provide a constructor of the type of collection, just the
collection initializer.

fixes #9