### PR TITLE
Prevent mixing different types of definitions

### DIFF
--- a/src/Sharpliner.Model/AzureDevOps/ConditionedStageDefinitions.cs
+++ b/src/Sharpliner.Model/AzureDevOps/ConditionedStageDefinitions.cs
@@ -5,7 +5,7 @@
     /// </summary>
     public static class ConditionedStageDefinitions
     {
-        public static ConditionedDefinition<Stage> Stage(this Condition condition, Stage stage)
+        public static ConditionedDefinition<Stage> Stage(this Condition<Stage> condition, Stage stage)
             => ConditionedDefinition.Link(condition, stage);
 
         public static ConditionedDefinition<Stage> Stage(

--- a/src/Sharpliner.Model/AzureDevOps/ConditionedVariableDefinitions.cs
+++ b/src/Sharpliner.Model/AzureDevOps/ConditionedVariableDefinitions.cs
@@ -7,16 +7,16 @@ namespace Sharpliner.Model.AzureDevOps
     /// </summary>
     public static class ConditionedVariableDefinitions
     {
-        public static ConditionedDefinition<VariableBase> Variable(this Condition condition, string name, string value)
+        public static ConditionedDefinition<VariableBase> Variable(this Condition<VariableBase> condition, string name, string value)
             => ConditionedDefinition.Link<VariableBase>(condition, new Variable(name, value));
 
-        public static ConditionedDefinition<VariableBase> Variable(this Condition condition, string name, bool value)
+        public static ConditionedDefinition<VariableBase> Variable(this Condition<VariableBase> condition, string name, bool value)
             => ConditionedDefinition.Link<VariableBase>(condition, new Variable(name, value));
 
-        public static ConditionedDefinition<VariableBase> Variable(this Condition condition, string name, int value)
+        public static ConditionedDefinition<VariableBase> Variable(this Condition<VariableBase> condition, string name, int value)
             => ConditionedDefinition.Link<VariableBase>(condition, new Variable(name, value));
 
-        public static ConditionedDefinition<VariableBase> Group(this Condition condition, string name)
+        public static ConditionedDefinition<VariableBase> Group(this Condition<VariableBase> condition, string name)
             => ConditionedDefinition.Link<VariableBase>(condition, new VariableGroup(name));
 
         public static ConditionedDefinition<VariableBase> Variable(

--- a/src/Sharpliner.Model/ConditionedDefinitions/ConditionBuilder.cs
+++ b/src/Sharpliner.Model/ConditionedDefinitions/ConditionBuilder.cs
@@ -32,21 +32,15 @@
         public Condition<T> Or(Condition<T> condition1, Condition<T> condition2)
             => Link(new OrCondition<T>(condition1, condition2));
 
-        public Condition And(Condition condition1, Condition condition2)
-            => Link(new AndCondition(condition1, condition2));
+        public Condition<T> And(Condition condition1, Condition condition2)
+            => Link(new AndCondition<T>(condition1, condition2));
 
-        public Condition Or(Condition condition1, Condition condition2)
-            => Link(new OrCondition(condition1, condition2));
-
-        private Condition Link(Condition condition)
-        {
-            condition.Parent = Parent;
-            return condition;
-        }
+        public Condition<T> Or(Condition condition1, Condition condition2)
+            => Link(new OrCondition<T>(condition1, condition2));
 
         private Condition<T> Link(Condition<T> condition)
         {
-            Link((Condition)condition);
+            condition.Parent = Parent;
             return condition;
         }
     }


### PR DESCRIPTION
You won't get Intellisense for `.Stage()` in a variable block