### PR TITLE
[Model] GithubAction - Add permissions to the workflow.

### DIFF
--- a/src/Sharpliner.Model/GHActions/Permissions.cs
+++ b/src/Sharpliner.Model/GHActions/Permissions.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+
+namespace Sharpliner.Model.GHActions
+{
+    public enum GitHubPermissionScope
+    {
+        Actions,
+        Checks,
+        Contents,
+        Deployments,
+        Issues,
+        Packages,
+        PullRequests,
+        RepositoryProjects,
+        SecurityEvents,
+        Statuses,
+    }
+
+    public enum GitHubPermission
+    {
+        None,
+        Read,
+        Write
+    }
+
+    public record Permissions
+    {
+        public HashSet<GitHubPermissionScope> Read { get; } = new();
+        public HashSet<GitHubPermissionScope> Write { get; } = new();
+
+        public Permissions All(GitHubPermission permission)
+        {
+            // loop and add, we are not worried because it is a hasset, we add
+            // to the correct hashset or remove from both in the case of None
+            foreach (var scope in Enum.GetValues<GitHubPermissionScope>())
+            {
+                switch (permission)
+                {
+                    case GitHubPermission.Read:
+                        Read.Add(scope);
+                        break;
+                    case GitHubPermission.Write:
+                        Write.Add(scope);
+                        break;
+                    default:
+                        Read.Remove(scope);
+                        Write.Remove(scope);
+                        break;
+                }
+            }
+            return this;
+        }
+
+    }
+}

--- a/src/Sharpliner.Model/GHActions/Workflow.cs
+++ b/src/Sharpliner.Model/GHActions/Workflow.cs
@@ -34,5 +34,10 @@ namespace Sharpliner.Model.GHActions
         /// </summary>
         public Trigger On { get; } = new ();
 
+        /// <summary>
+        /// Allows to set the permissions granted to the Github token that will be used with the workflow. This
+        /// setting will apply to all the jobs in a workflow. You can override this setting per job.
+        /// </summary>
+        public Permissions Permissions { get; init; } = new ();
     }
 }

--- a/tests/Sharpliner.Model.Tests/GitHub/WorkflowTests.cs
+++ b/tests/Sharpliner.Model.Tests/GitHub/WorkflowTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Sharpliner.Model.GHActions;
 using Xunit;
 
@@ -149,6 +150,146 @@ namespace Sharpliner.Model.Tests.GitHub
             Assert.Null(w.On.Manuals.RepositoryDispatch);
             Assert.Empty(w.On.Schedules);
             Assert.Equal(2, w.On.Webhooks.Count);
+        }
+
+        [Fact]
+        public void Workflow_ReadAll_Permissions()
+        {
+            var w = new Workflow
+            {
+                On =
+                {
+                    Webhooks =
+                    {
+                        new PullRequest
+                        {
+                            Activities = { PullRequest.Activity.Assigned, PullRequest.Activity.Closed }
+                        }
+                    }
+                },
+                Permissions = new Permissions().All(GitHubPermission.Read)
+            };
+            foreach (var scope in Enum.GetValues<GitHubPermissionScope>())
+            {
+                Assert.Contains(scope, w.Permissions.Read);
+            }
+        }
+
+        [Fact]
+        public void Workflow_WriteAll_Permissions()
+        {
+
+            var w = new Workflow
+            {
+                On =
+                {
+                    Webhooks =
+                    {
+                        new PullRequest
+                        {
+                            Activities = { PullRequest.Activity.Assigned, PullRequest.Activity.Closed }
+                        }
+                    }
+                },
+                Permissions = new Permissions().All(GitHubPermission.Write)
+            };
+            foreach (var scope in Enum.GetValues<GitHubPermissionScope>())
+            {
+                Assert.Contains(scope, w.Permissions.Write);
+            }
+        }
+
+        [Fact]
+        public void Workflow_OneRead_WriteAll_Permissions()
+        {
+
+            var w = new Workflow
+            {
+                On =
+                {
+                    Webhooks =
+                    {
+                        new PullRequest
+                        {
+                            Activities = { PullRequest.Activity.Assigned, PullRequest.Activity.Closed }
+                        }
+                    }
+                },
+                Permissions = new Permissions
+                {
+                    Read =
+                    {
+                        GitHubPermissionScope.Actions,
+                    }
+                }.All(GitHubPermission.Write)
+            };
+            Assert.Contains(GitHubPermissionScope.Actions, w.Permissions.Read);
+            foreach (var scope in Enum.GetValues<GitHubPermissionScope>())
+            {
+                Assert.Contains(scope, w.Permissions.Write);
+            }
+        }
+
+        [Fact]
+        public void Workflow_OneWrite_ReadAll_Permissions()
+        {
+            var w = new Workflow
+            {
+                On =
+                {
+                    Webhooks =
+                    {
+                        new PullRequest
+                        {
+                            Activities = { PullRequest.Activity.Assigned, PullRequest.Activity.Closed }
+                        }
+                    }
+                },
+                Permissions = new Permissions
+                {
+                    Write =
+                    {
+                        GitHubPermissionScope.Actions,
+                    }
+                }.All(GitHubPermission.Read)
+            };
+            Assert.Contains(GitHubPermissionScope.Actions, w.Permissions.Write);
+            foreach (var scope in Enum.GetValues<GitHubPermissionScope>())
+            {
+                Assert.Contains(scope, w.Permissions.Read);
+            }
+        }
+
+        [Fact]
+        public void Workflow_Detailed_Permissions()
+        {
+            var w = new Workflow
+            {
+                On =
+                {
+                    Webhooks =
+                    {
+                        new PullRequest
+                        {
+                            Activities = { PullRequest.Activity.Assigned, PullRequest.Activity.Closed }
+                        }
+                    }
+                },
+                Permissions =
+                {
+                    Write =
+                    {
+                        GitHubPermissionScope.Actions,
+                    },
+                    Read = {
+                        GitHubPermissionScope.Actions,
+                        GitHubPermissionScope.Contents
+                    }
+                }
+            };
+            Assert.Contains(GitHubPermissionScope.Actions, w.Permissions.Write);
+            Assert.Contains(GitHubPermissionScope.Actions, w.Permissions.Read);
+            Assert.Contains(GitHubPermissionScope.Contents, w.Permissions.Read);
         }
     }
 }


### PR DESCRIPTION
Allow to set the persmissions for a workflow, there are several ways to
use the API.

1. Provide each scope we want to Read or Write

```csharp
Permissions =
{
    Write =
    {
        GitHubPermissionScope.Actions,
    },
    Read = {
        GitHubPermissionScope.Actions,
        GitHubPermissionScope.Contents
    }
}
```

2. Read All

Use the fluent API

```csharp
Permissions = new Permissions().All(GitHubPermission.Read)
```

3. Write All

Use the fluent API

```csharp
Permissions = new Permissions().All(GitHubPermission.Write)
```

4. Read and Write All

Use the fluent API

```csharp
Permissions = new Permissions().All(GitHubPermission.Write).All(GitHubPermission.Read)
```

5. A mix of Read/Write All and more specific

Use a mix of declarative + fluet:
```csharp
Permissions = new Permissions
{
  Read =
  {
    GitHubPermissionScope.Actions,
  }
}.All(GitHubPermission.Write)
```

The above API will also be used for jobs.