### PR TITLE
Report target YAML path and whether there were changes during publishing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,6 @@ stages:
       vmImage: windows-latest
       name: Azure Pipelines
     steps:
-
     - task: UseDotNet@2
       displayName: Install .NET 6 preview 3
       inputs:

--- a/src/Sharpliner.Tools/PublishPipelines.cs
+++ b/src/Sharpliner.Tools/PublishPipelines.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.InteropServices.ComTypes;
 using System.Security.Cryptography;
 using Microsoft.Build.Framework;
 using Sharpliner.Definition;

--- a/src/Sharpliner.Tools/PublishPipelines.cs
+++ b/src/Sharpliner.Tools/PublishPipelines.cs
@@ -2,6 +2,8 @@
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices.ComTypes;
+using System.Security.Cryptography;
 using Microsoft.Build.Framework;
 using Sharpliner.Definition;
 
@@ -87,16 +89,56 @@ namespace Sharpliner.Tools
         private void PublishPipeline(object pipelineDefinition)
         {
             Type type = pipelineDefinition.GetType();
-            var method = type.GetMethod(nameof(PipelineDefinitionBase.Publish));
+            var getPath = type.GetMethod(nameof(PipelineDefinitionBase.GetTargetPath));
+            var publish = type.GetMethod(nameof(PipelineDefinitionBase.Publish));
 
-            if (method is null)
+            if (publish is null || getPath is null)
             {
                 Log.LogError($"Failed to get pipeline definition metadata for {type.FullName}");
                 return;
             }
 
-            Log.LogMessage(MessageImportance.High, $"Publishing pipeline {type.Name}");
-            method.Invoke(pipelineDefinition, null);
+            if (getPath.Invoke(pipelineDefinition, null) is not string path)
+            {
+                Log.LogError($"Failed to get target path for {type.Name} ");
+                return;
+            }
+
+            Log.LogMessage(MessageImportance.High, $"Publishing pipeline {type.Name} to {path}");
+
+            string? hash = GetFileHash(path);
+
+            // Publish pipeline
+            publish.Invoke(pipelineDefinition, null);
+
+            if (hash == null)
+            {
+                Log.LogMessage(MessageImportance.High, $"YAML for {type.Name} created at {path}");
+            }
+            else
+            {
+                var newHash = GetFileHash(path);
+                if (hash == newHash)
+                {
+                    Log.LogMessage(MessageImportance.High, $"No new changes to publish for {type.Name}");
+                }
+                else
+                {
+                    Log.LogMessage(MessageImportance.High, $"Published new changes for {type.Name}");
+                }
+            }
+        }
+
+        private static string? GetFileHash(string path)
+        {
+            if (!File.Exists(path))
+            {
+                return null;
+            }
+
+            using var md5 = MD5.Create();
+            using var stream = File.OpenRead(path);
+            return System.Text.Encoding.UTF8.GetString(md5.ComputeHash(stream));
         }
     }
 }

--- a/src/Sharpliner/AzureDevOps/AzureDevOpsPipelineDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/AzureDevOpsPipelineDefinition.cs
@@ -31,6 +31,7 @@ namespace Sharpliner.AzureDevOps
             yaml = Regex.Replace(yaml, "((\r?\n)[a-zA-Z]+:)", Environment.NewLine + "$1");
             yaml = Regex.Replace(yaml, "((\r?\n)    - task: )", Environment.NewLine + "$1");
             yaml = Regex.Replace(yaml, "((\r?\n) {0,8}- \\${{ if [^\n](\r?\n)    - task: )", Environment.NewLine + "$1");
+            yaml = Regex.Replace(yaml, "(:\r?\n\r?\n)", ":" + Environment.NewLine);
 
             return yaml;
         }

--- a/src/Sharpliner/PipelineDefinitionBase.cs
+++ b/src/Sharpliner/PipelineDefinitionBase.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using Sharpliner.AzureDevOps;
@@ -68,6 +67,41 @@ namespace Sharpliner.Definition
             }
 
             File.WriteAllText(fileName, Serialize());
+        }
+
+        /// <summary>
+        /// Gets the path where YAML of this definition should be published to.
+        /// </summary>
+        public string GetTargetPath()
+        {
+            switch (TargetPathType)
+            {
+                case TargetPathType.RelativeToGitRoot:
+                    var currentDir = new DirectoryInfo(Directory.GetCurrentDirectory());
+                    while (!Directory.Exists(Path.Combine(currentDir.FullName, ".git")))
+                    {
+                        currentDir = currentDir.Parent;
+
+                        if (currentDir == null)
+                        {
+                            throw new Exception($"Failed to find git repository in {Directory.GetParent(Assembly.GetExecutingAssembly().Location)?.FullName}");
+                        }
+                    }
+
+                    return Path.Combine(currentDir.FullName, TargetFile);
+
+                case TargetPathType.RelativeToCurrentDir:
+                    return TargetFile;
+
+                case TargetPathType.RelativeToAssembly:
+                    return Path.Combine(Assembly.GetExecutingAssembly().Location, TargetFile);
+
+                case TargetPathType.Absolute:
+                    return TargetFile;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(TargetPathType));
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
```
D:\github\Sharpliner\eng\Sharpliner.CI
λ  dotnet build
Microsoft (R) Build Engine version 16.10.0-preview-21181-07+073022eb4 for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  All projects are up-to-date for restore.
  Sharpliner.CI -> D:\github\Sharpliner\artifacts\bin\Sharpliner.CI\net5.0\Sharpliner.CI.dll
  Publishing all pipeline definitions inside D:\github\Sharpliner\artifacts\bin\Sharpliner.CI\net5.0\Sharpliner.CI.dll
  Publishing pipeline SharplinerPipeline to D:\github\Sharpliner\azure-pipelines.yml
  Published new changes for SharplinerPipeline

Build succeeded.
    0 Warning(s)
    0 Error(s)
```