### PR TITLE
[GithubActions/VSTS] Move the task builder to a common name space

### DIFF
--- a/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/BashTaskBuilder.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/BashTaskBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using Sharpliner.Common.Model.Tasks;
 
 namespace Sharpliner.AzureDevOps.Tasks
 {

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/PowerShellTaskBuilder.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/PowerShellTaskBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using Sharpliner.Common.Model.Tasks;
 
 namespace Sharpliner.AzureDevOps.Tasks
 {

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/ScriptTaskBuilder.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/ScriptTaskBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using Sharpliner.Common.Model.Tasks;
 
 namespace Sharpliner.AzureDevOps.Tasks
 {

--- a/src/Sharpliner/Common/Model/Tasks/TaskBuilderBase.cs
+++ b/src/Sharpliner/Common/Model/Tasks/TaskBuilderBase.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Reflection;
 
-namespace Sharpliner.AzureDevOps.Tasks
+namespace Sharpliner.Common.Model.Tasks
 {
     public abstract class TaskBuilderBase
     {


### PR DESCRIPTION
The class is useful to implement the Run in GithubActions.