### PR TITLE
Load user assembly with absolute path

### DIFF
--- a/src/Sharpliner/PublishPipelines.cs
+++ b/src/Sharpliner/PublishPipelines.cs
@@ -66,7 +66,8 @@ namespace Sharpliner
             // Preload dependencies needed for things to work
             var assemblies = new[] { "YamlDotNet.dll", "Sharpliner.dll" }
                 .Select(assemblyName => Path.Combine(Path.GetDirectoryName(assemblyPath) ?? throw new Exception($"Failed to find directory of {assemblyPath}"), assemblyName))
-                .Select(path => System.Reflection.Assembly.LoadFile(path) ?? throw new Exception($"Failed to find a Sharpliner dependency at {path}. Make sure your bin/ contains this library."))
+                .Select(Path.GetFullPath)
+                .Select(path => System.Reflection.Assembly.LoadFile(path) ?? throw new Exception($"Failed to find a Sharpliner dependency at {path}. Make sure the bin/ directory of your project contains this library."))
                 .Where(a => a is not null)
                 .ToDictionary(a => a.FullName!);
 


### PR DESCRIPTION
When trying to use the NuGet, I got this:
```
  Publishing all pipeline definitions inside bin\Debug\net5.0\ClassLibrary1.dll
E:\NuGet\packages\sharpliner\0.3.0\build\Sharpliner.targets(9,5): error MSB4018: The "PublishPipelines" task failed unexpectedly. [C:\Users\prvysoky\Desktop\ClassLibrary1\ClassLibrary1.csproj]
E:\NuGet\packages\sharpliner\0.3.0\build\Sharpliner.targets(9,5): error MSB4018: System.ArgumentException: Path "bin\Debug\net5.0\YamlDotNet.dll" is not an absolute path. (Parameter 'path') [C:\Users\prvysoky\Desktop\ClassLibrary1\ClassLibrary1.csproj]
E:\NuGet\packages\sharpliner\0.3.0\build\Sharpliner.targets(9,5): error MSB4018:    at System.Reflection.Assembly.LoadFile(String path) [C:\Users\prvysoky\Desktop\ClassLibrary1\ClassLibrary1.csproj]
E:\NuGet\packages\sharpliner\0.3.0\build\Sharpliner.targets(9,5): error MSB4018:    at Sharpliner.PublishPipelines.<>c.<LoadAssembly>b__10_1(String path) [C:\Users\prvysoky\Desktop\ClassLibrary1\ClassLibrary1.csproj]
E:\NuGet\packages\sharpliner\0.3.0\build\Sharpliner.targets(9,5): error MSB4018:    at System.Linq.Utilities.<>c__DisplayClass2_0`3.<CombineSelectors>b__0(TSource x) [C:\Users\prvysoky\Desktop\ClassLibrary1\ClassLibrary1.csproj]
E:\NuGet\packages\sharpliner\0.3.0\build\Sharpliner.targets(9,5): error MSB4018:    at System.Linq.Enumerable.SelectArrayIterator`2.MoveNext() [C:\Users\prvysoky\Desktop\ClassLibrary1\ClassLibrary1.csproj]
E:\NuGet\packages\sharpliner\0.3.0\build\Sharpliner.targets(9,5): error MSB4018:    at System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext() [C:\Users\prvysoky\Desktop\ClassLibrary1\ClassLibrary1.csproj]
E:\NuGet\packages\sharpliner\0.3.0\build\Sharpliner.targets(9,5): error MSB4018:    at System.Linq.Enumerable.ToDictionary[TSource,TKey](IEnumerable`1 source, Func`2 keySelector, IEqualityComparer`1 comparer) [C:\Users\prvysoky\Desktop\ClassLibrary1\ClassLibrary1.csproj]
E:\NuGet\packages\sharpliner\0.3.0\build\Sharpliner.targets(9,5): error MSB4018:    at System.Linq.Enumerable.ToDictionary[TSource,TKey](IEnumerable`1 source, Func`2 keySelector) [C:\Users\prvysoky\Desktop\ClassLibrary1\ClassLibrary1.csproj]
E:\NuGet\packages\sharpliner\0.3.0\build\Sharpliner.targets(9,5): error MSB4018:    at Sharpliner.PublishPipelines.LoadAssembly(String assemblyPath) [C:\Users\prvysoky\Desktop\ClassLibrary1\ClassLibrary1.csproj]
E:\NuGet\packages\sharpliner\0.3.0\build\Sharpliner.targets(9,5): error MSB4018:    at Sharpliner.PublishPipelines.PublishAllPipelines[T]() [C:\Users\prvysoky\Desktop\ClassLibrary1\ClassLibrary1.csproj]
E:\NuGet\packages\sharpliner\0.3.0\build\Sharpliner.targets(9,5): error MSB4018:    at Sharpliner.PublishPipelines.Execute() [C:\Users\prvysoky\Desktop\ClassLibrary1\ClassLibrary1.csproj]
E:\NuGet\packages\sharpliner\0.3.0\build\Sharpliner.targets(9,5): error MSB4018:    at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute() [C:\Users\prvysoky\Desktop\ClassLibrary1\ClassLibrary1.csproj]
E:\NuGet\packages\sharpliner\0.3.0\build\Sharpliner.targets(9,5): error MSB4018:    at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask) [C:\Users\prvysoky\Desktop\ClassLibrary1\ClassLibrary1.csproj]
```