### PR TITLE
Use 43.43.43 as the dummy version to avoid problems

### DIFF
--- a/eng/Sharpliner.CI/Sharpliner.CI.csproj
+++ b/eng/Sharpliner.CI/Sharpliner.CI.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <!-- These will appear in artifacts/packages after you call `dotnet pack` -->
-    <PackageReference Include="Sharpliner" Version="42.42.42" />
+    <PackageReference Include="Sharpliner" Version="43.43.43" />
   </ItemGroup>
 
   <!--
@@ -30,7 +30,7 @@
     <Exec Condition=" '$(OS)' != 'Windows_NT' " Command="$(MSBuildThisFileDirectory)clean-dependencies.sh" />
     <Exec Condition=" '$(OS)' == 'Windows_NT' " Command="powershell.exe -NonInteractive -ExecutionPolicy Unrestricted $(MSBuildThisFileDirectory)clean-dependencies.ps1" />
   </Target>
-  
+
   <Target Name="BuildDependencies" BeforeTargets="_GenerateRestoreProjectSpec">
     <Exec Condition=" '$(OS)' != 'Windows_NT' " Command="$(MSBuildThisFileDirectory)build-dependencies.sh" />
     <Exec Condition=" '$(OS)' == 'Windows_NT' " Command="powershell.exe -NonInteractive -ExecutionPolicy Unrestricted $(MSBuildThisFileDirectory)build-dependencies.ps1" />

--- a/eng/Sharpliner.CI/build-dependencies.ps1
+++ b/eng/Sharpliner.CI/build-dependencies.ps1
@@ -9,7 +9,7 @@ if (-not(Test-Path "$repo_root/artifacts/packages")) {
     New-Item -Path "$repo_root/artifacts" -Name "packages" -ItemType "directory" | out-null
 }
 
-if (-not(Test-Path "$repo_root/artifacts/packages/Sharpliner.42.42.42.nupkg")) {
+if (-not(Test-Path "$repo_root/artifacts/packages/Sharpliner.43.43.43.nupkg")) {
     Write-Host "Building Sharpliner nupkg for Sharpliner.CI..."
-    dotnet pack --nologo "$repo_root/src/Sharpliner/Sharpliner.csproj" -p:PackageVersion=42.42.42 -c:Release
+    dotnet pack --nologo "$repo_root/src/Sharpliner/Sharpliner.csproj" -p:PackageVersion=43.43.43 -c:Release
 }

--- a/eng/Sharpliner.CI/build-dependencies.sh
+++ b/eng/Sharpliner.CI/build-dependencies.sh
@@ -16,8 +16,8 @@ repo_root="$here/../../"
 
 # Prepare local packages
 
-if [ ! -f "$repo_root/artifacts/packages/Sharpliner.42.42.42.nupkg" ]; then
+if [ ! -f "$repo_root/artifacts/packages/Sharpliner.43.43.43.nupkg" ]; then
   mkdir -p "$repo_root/artifacts/packages"
   echo "Building Sharpliner nupkg for Sharpliner.CI..."
-  dotnet pack --nologo "$repo_root/src/Sharpliner/Sharpliner.csproj" -p:PackageVersion=42.42.42 -c:Release
+  dotnet pack --nologo "$repo_root/src/Sharpliner/Sharpliner.csproj" -p:PackageVersion=43.43.43 -c:Release
 fi


### PR DESCRIPTION
The problem is that once, I pushed 42.42.42 to NuGet.org by mistake and now when we don't build the 42.42.42 locally well, we pull it from nuget.org and it is not working so it feels like your local version is not working.