### PR TITLE
Allow to add empty dependsOn

### DIFF
--- a/src/Sharpliner/AzureDevOps/AzureDevOpsDefinitions.cs
+++ b/src/Sharpliner/AzureDevOps/AzureDevOpsDefinitions.cs
@@ -1,4 +1,5 @@
-﻿using Sharpliner.AzureDevOps.Tasks;
+﻿using System.Collections.Generic;
+using Sharpliner.AzureDevOps.Tasks;
 using Sharpliner.Definition;
 
 namespace Sharpliner.AzureDevOps
@@ -140,6 +141,12 @@ namespace Sharpliner.AzureDevOps
             => Script
                 .Inline($"dotnet build \"{pipelineProject}\" -p:{nameof(PublishPipelines.FailIfChanged)}=true")
                 .DisplayAs("Validate YAML has been published");
+
+        /// <summary>
+        /// AzDO allows an empty dependsOn which then forces the stage/job to kick off in parallel.
+        /// If dependsOn is omitted, stages/jobs run in the order they are defined.
+        /// </summary>
+        protected static List<string> NoDependsOn => new EmptyDependsOn();
 
         protected static Condition<T> And<T>(Condition condition1, Condition condition2) => new AndCondition<T>(condition1, condition2);
 

--- a/src/Sharpliner/AzureDevOps/Model/IDependsOn.cs
+++ b/src/Sharpliner/AzureDevOps/Model/IDependsOn.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
 
 namespace Sharpliner.AzureDevOps
 {
@@ -6,5 +10,22 @@ namespace Sharpliner.AzureDevOps
     {
         string Name { get; }
         List<string> DependsOn { get; }
+    }
+
+    /// <summary>
+    /// AzDO allows an empty dependsOn which then forces the stage/job to kick off in parallel.
+    /// If dependsOn is omitted, stages/jobs run in the order they are defined.
+    /// </summary>
+    internal class EmptyDependsOn : List<string>, IYamlConvertible
+    {
+        public void Read(IParser parser, Type expectedType, ObjectDeserializer nestedObjectDeserializer) => throw new NotImplementedException();
+
+        // We want to write "dependsOn: " (empty value)
+        public void Write(IEmitter emitter, ObjectSerializer nestedObjectSerializer) => emitter.Emit(new Scalar(string.Empty));
+
+        public EmptyDependsOn()
+        {
+            Add(string.Empty);
+        }
     }
 }

--- a/src/Sharpliner/AzureDevOps/Pipeline.cs
+++ b/src/Sharpliner/AzureDevOps/Pipeline.cs
@@ -73,6 +73,11 @@ namespace Sharpliner.AzureDevOps
 
             foreach (var definition in allDefs)
             {
+                if (definition.DependsOn is EmptyDependsOn)
+                {
+                    continue;
+                }
+
                 foreach (var dependsOn in definition.DependsOn)
                 {
                     if (dependsOn == definition.Name)

--- a/tests/Sharpliner.Tests/AzureDevOps/XHarnessPipeline.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/XHarnessPipeline.cs
@@ -130,6 +130,7 @@ namespace Sharpliner.Tests.AzureDevOps
                 If.Equal(variables["_RunAsPublic"], "True")
                     .Stage(new Stage("Build_OSX", "Build OSX")
                     {
+                        DependsOn = NoDependsOn,
                         Jobs = {
                             new Template<Job>("/eng/common/templates/jobs/jobs.yml")
                             {
@@ -215,70 +216,70 @@ namespace Sharpliner.Tests.AzureDevOps
                     })
 
                 // E2E tests
-                    .Template("eng/e2e-test.yml", new TemplateParameters
+                    .Template("eng/e2e-test.yml", new()
                     {
                         { "name", "E2E_Android_Simulators" },
                         { "displayName", "Android - Simulators" },
                         { "testProject", "$(Build.SourcesDirectory)/tests/integration-tests/Android/Simulator.Tests.proj" },
                     })
 
-                    .Template("eng/e2e-test.yml", new TemplateParameters
+                    .Template("eng/e2e-test.yml", new()
                     {
                         { "name", "E2E_Android_Devices" },
                         { "displayName", "Android - Devices" },
                         { "testProject", "$(Build.SourcesDirectory)/tests/integration-tests/Android/Device.Tests.proj" },
                     })
 
-                    .Template("eng/e2e-test.yml", new TemplateParameters
+                    .Template("eng/e2e-test.yml", new()
                     {
                         { "name", "E2E_Android_Manual_Commands" },
                         { "displayName", "Android - Manual Commands" },
                         { "testProject", "$(Build.SourcesDirectory)/tests/integration-tests/Android/Commands.Tests.proj" },
                     })
 
-                    .Template("eng/e2e-test.yml", new TemplateParameters
+                    .Template("eng/e2e-test.yml", new()
                     {
                         { "name", "E2E_Apple_Simulators" },
                         { "displayName", "Apple - Simulators" },
                         { "testProject", "$(Build.SourcesDirectory)/tests/integration-tests/Apple/Simulator.Tests.proj" },
                     })
 
-                    .Template("eng/e2e-test.yml", new TemplateParameters
+                    .Template("eng/e2e-test.yml", new()
                     {
                         { "name", "E2E_iOS_Devices" },
                         { "displayName", "Apple - iOS devices" },
                         { "testProject", "$(Build.SourcesDirectory)/tests/integration-tests/Apple/Device.iOS.Tests.proj" },
                     })
 
-                    .Template("eng/e2e-test.yml", new TemplateParameters
+                    .Template("eng/e2e-test.yml", new()
                     {
                         { "name", "E2E_tvOS_Devices" },
                         { "displayName", "Apple - tvOS devices" },
                         { "testProject", "$(Build.SourcesDirectory)/tests/integration-tests/Apple/Device.tvOS.Tests.proj" },
                     })
 
-                    .Template("eng/e2e-test.yml", new TemplateParameters
+                    .Template("eng/e2e-test.yml", new()
                     {
                         { "name", "E2E_Apple_Simulator_Commands" },
                         { "displayName", "Apple - Simulator Commands" },
                         { "testProject", "$(Build.SourcesDirectory)/tests/integration-tests/Apple/Simulator.Commands.Tests.proj" },
                     })
 
-                    .Template("eng/e2e-test.yml", new TemplateParameters
+                    .Template("eng/e2e-test.yml", new()
                     {
                         { "name", "E2E_Apple_Device_Commands" },
                         { "displayName", "Apple - Device Commands" },
                         { "testProject", "$(Build.SourcesDirectory)/tests/integration-tests/Apple/Device.Commands.Tests.proj" },
                     })
 
-                    .Template("eng/e2e-test.yml", new TemplateParameters
+                    .Template("eng/e2e-test.yml", new()
                     {
                         { "name", "E2E_Apple_Simulator_Mgmt" },
                         { "displayName", "Apple - Simulator management" },
                         { "testProject", "$(Build.SourcesDirectory)/tests/integration-tests/Apple/SimulatorInstaller.Tests.proj" },
                     })
 
-                    .Template("eng/e2e-test.yml", new TemplateParameters
+                    .Template("eng/e2e-test.yml", new()
                     {
                         { "name", "E2E_WASM" },
                         { "displayName", "WASM" },
@@ -287,7 +288,7 @@ namespace Sharpliner.Tests.AzureDevOps
 
                 // NuGet publishing
                 If.Equal(variables["_RunAsInternal"], "True")
-                    .Template<Stage>("eng/common/templates/post-build/post-build.yml", new TemplateParameters()
+                    .Template<Stage>("eng/common/templates/post-build/post-build.yml", new()
                     {
                         { "publishingInfraVersion", 3 },
                         { "enableSymbolValidation", true },
@@ -296,7 +297,7 @@ namespace Sharpliner.Tests.AzureDevOps
                         { "publishDependsOn", new[] { "Validate" } },
 
                         // This is to enable SDL runs part of Post-Build Validation Stage
-                        { "SDLValidationParameters", new TemplateParameters
+                        { "SDLValidationParameters", new TemplateParameters()
                             {
                                 { "enable", false },
                                 { "continueOnError", false },


### PR DESCRIPTION
AzDO allows an empty dependsOn which then forces the stage/job to kick off in parallel. If dependsOn is omitted, stages/jobs run in the order they are defined.