### PR TITLE
AzureDevOps API improvements and publishing fixes

### DIFF
--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -1,9 +1,9 @@
-### 
+###
 ### DO NOT MODIFY THIS FILE!
-### 
+###
 ### This YAML was auto-generated from PullRequestPipeline.cs
 ### To make changes, change the C# definition and rebuild its project
-### 
+###
 
 trigger:
   batch: true

--- a/eng/pipelines/publish.yml
+++ b/eng/pipelines/publish.yml
@@ -1,9 +1,9 @@
-### 
+###
 ### DO NOT MODIFY THIS FILE!
-### 
+###
 ### This YAML was auto-generated from PublishPipeline.cs
 ### To make changes, change the C# definition and rebuild its project
-### 
+###
 
 jobs:
 - job: Publish

--- a/eng/pipelines/templates/install-dotnet.yml
+++ b/eng/pipelines/templates/install-dotnet.yml
@@ -1,9 +1,9 @@
-### 
+###
 ### DO NOT MODIFY THIS FILE!
-### 
+###
 ### This YAML was auto-generated from InstallDotNetTemplate.cs
 ### To make changes, change the C# definition and rebuild its project
-### 
+###
 
 parameters:
 - name: version

--- a/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
@@ -166,6 +166,10 @@ public abstract class AzureDevOpsDefinition : PipelineDefinitionBase
 
     protected static Condition<T> NotEqual<T>(string expression1, string expression2) => new EqualityCondition<T>(expression1, expression2, false);
 
+    protected static Condition And(string condition1, string condition2) => new AndCondition(condition1, condition2);
+
+    protected static Condition Or(string condition1, string condition2) => new OrCondition(condition1, condition2);
+
     protected static Condition And(Condition condition1, Condition condition2) => new AndCondition(condition1, condition2);
 
     protected static Condition Or(Condition condition1, Condition condition2) => new OrCondition(condition1, condition2);

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/Condition.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/Condition.cs
@@ -58,6 +58,11 @@ public class EqualityCondition : Condition
 public class AndCondition : Condition
 {
     internal AndCondition(Condition expression1, Condition expression2)
+        : this(expression1.ToString(), expression2.ToString())
+    {
+    }
+
+    internal AndCondition(string expression1, string expression2)
         : base($"and({expression1}, {expression2})")
     {
     }
@@ -66,6 +71,11 @@ public class AndCondition : Condition
 public class OrCondition : Condition
 {
     internal OrCondition(Condition expression1, Condition expression2)
+        : this(expression1.ToString(), expression2.ToString())
+    {
+    }
+
+    internal OrCondition(string expression1, string expression2)
         : base($"or({expression1}, {expression2})")
     {
     }

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/ConditionedExtensions.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/ConditionedExtensions.cs
@@ -125,22 +125,6 @@ public static class ConditionedExtensions
     }
 
     /// <summary>
-    /// Reference a YAML template.
-    /// </summary>
-    /// <param name="conditionedDefinition">Conditioned definition</param>
-    /// <param name="path">Relative path to the YAML file with the template</param>
-    /// <param name="parameters">Values for template parameters</param>
-    public static Conditioned<T> Template<T>(
-        this Conditioned<T> conditionedDefinition,
-        string path,
-        TemplateParameters parameters)
-    {
-        var template = new Template<T>(path: path, parameters);
-        conditionedDefinition.Definitions.Add(template);
-        return conditionedDefinition;
-    }
-
-    /// <summary>
     /// Reference a YAML stage template.
     /// </summary>
     /// <param name="conditionedDefinition">Conditioned definition</param>

--- a/src/Sharpliner/PipelineDefinitionBase.cs
+++ b/src/Sharpliner/PipelineDefinitionBase.cs
@@ -80,6 +80,12 @@ public abstract class PipelineDefinitionBase
             fileContents = fileContents.Replace(" \r\n", "\r\n").Replace(" \n", "\n"); // Remove trailing spaces from the default template
         }
 
+        var targetDirectory = Path.GetDirectoryName(fileName)!;
+        if (!Directory.Exists(targetDirectory))
+        {
+            Directory.CreateDirectory(targetDirectory);
+        }
+
         File.WriteAllText(fileName, fileContents);
     }
 

--- a/src/Sharpliner/PipelineDefinitionBase.cs
+++ b/src/Sharpliner/PipelineDefinitionBase.cs
@@ -77,6 +77,7 @@ public abstract class PipelineDefinitionBase
         {
             const string hash = "### ";
             fileContents = hash + string.Join(Environment.NewLine + hash, header) + Environment.NewLine + Environment.NewLine + fileContents;
+            fileContents = fileContents.Replace(" \r\n", "\r\n").Replace(" \n", "\n"); // Remove trailing spaces from the default template
         }
 
         File.WriteAllText(fileName, fileContents);

--- a/tests/Sharpliner.Tests/AzureDevOps/Pipelines/XHarnessPipeline.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/Pipelines/XHarnessPipeline.cs
@@ -216,70 +216,70 @@ internal class XHarnessPipeline : PipelineDefinition
                     })
 
                 // E2E tests
-                    .Template("eng/e2e-test.yml", new()
+                    .StageTemplate("eng/e2e-test.yml", new()
                     {
                         { "name", "E2E_Android_Simulators" },
                         { "displayName", "Android - Simulators" },
                         { "testProject", "$(Build.SourcesDirectory)/tests/integration-tests/Android/Simulator.Tests.proj" },
                     })
 
-                    .Template("eng/e2e-test.yml", new()
+                    .StageTemplate("eng/e2e-test.yml", new()
                     {
                         { "name", "E2E_Android_Devices" },
                         { "displayName", "Android - Devices" },
                         { "testProject", "$(Build.SourcesDirectory)/tests/integration-tests/Android/Device.Tests.proj" },
                     })
 
-                    .Template("eng/e2e-test.yml", new()
+                    .StageTemplate("eng/e2e-test.yml", new()
                     {
                         { "name", "E2E_Android_Manual_Commands" },
                         { "displayName", "Android - Manual Commands" },
                         { "testProject", "$(Build.SourcesDirectory)/tests/integration-tests/Android/Commands.Tests.proj" },
                     })
 
-                    .Template("eng/e2e-test.yml", new()
+                    .StageTemplate("eng/e2e-test.yml", new()
                     {
                         { "name", "E2E_Apple_Simulators" },
                         { "displayName", "Apple - Simulators" },
                         { "testProject", "$(Build.SourcesDirectory)/tests/integration-tests/Apple/Simulator.Tests.proj" },
                     })
 
-                    .Template("eng/e2e-test.yml", new()
+                    .StageTemplate("eng/e2e-test.yml", new()
                     {
                         { "name", "E2E_iOS_Devices" },
                         { "displayName", "Apple - iOS devices" },
                         { "testProject", "$(Build.SourcesDirectory)/tests/integration-tests/Apple/Device.iOS.Tests.proj" },
                     })
 
-                    .Template("eng/e2e-test.yml", new()
+                    .StageTemplate("eng/e2e-test.yml", new()
                     {
                         { "name", "E2E_tvOS_Devices" },
                         { "displayName", "Apple - tvOS devices" },
                         { "testProject", "$(Build.SourcesDirectory)/tests/integration-tests/Apple/Device.tvOS.Tests.proj" },
                     })
 
-                    .Template("eng/e2e-test.yml", new()
+                    .StageTemplate("eng/e2e-test.yml", new()
                     {
                         { "name", "E2E_Apple_Simulator_Commands" },
                         { "displayName", "Apple - Simulator Commands" },
                         { "testProject", "$(Build.SourcesDirectory)/tests/integration-tests/Apple/Simulator.Commands.Tests.proj" },
                     })
 
-                    .Template("eng/e2e-test.yml", new()
+                    .StageTemplate("eng/e2e-test.yml", new()
                     {
                         { "name", "E2E_Apple_Device_Commands" },
                         { "displayName", "Apple - Device Commands" },
                         { "testProject", "$(Build.SourcesDirectory)/tests/integration-tests/Apple/Device.Commands.Tests.proj" },
                     })
 
-                    .Template("eng/e2e-test.yml", new()
+                    .StageTemplate("eng/e2e-test.yml", new()
                     {
                         { "name", "E2E_Apple_Simulator_Mgmt" },
                         { "displayName", "Apple - Simulator management" },
                         { "testProject", "$(Build.SourcesDirectory)/tests/integration-tests/Apple/SimulatorInstaller.Tests.proj" },
                     })
 
-                    .Template("eng/e2e-test.yml", new()
+                    .StageTemplate("eng/e2e-test.yml", new()
                     {
                         { "name", "E2E_WASM" },
                         { "displayName", "WASM" },
@@ -288,7 +288,7 @@ internal class XHarnessPipeline : PipelineDefinition
 
                 // NuGet publishing
                 If.Equal(variables["_RunAsInternal"], "True")
-                    .Template<Stage>("eng/common/templates/post-build/post-build.yml", new()
+                    .StageTemplate("eng/common/templates/post-build/post-build.yml", new()
                     {
                         { "publishingInfraVersion", 3 },
                         { "enableSymbolValidation", true },

--- a/tests/Sharpliner.Tests/GitHub/JobTests.cs
+++ b/tests/Sharpliner.Tests/GitHub/JobTests.cs
@@ -231,13 +231,13 @@ namespace Sharpliner.Tests.GitHub
                 }
             };
 
-            Assert.Equal("nginx", j.Services[0].Container.Image);
+            Assert.Equal("nginx", j.Services[0]?.Container?.Image);
 
-            Assert.Contains(495, j.Services[1].Container.Ports);
-            Assert.Contains("my_docker_volume:/volume_mount", j.Services[1].Container.Volumes);
+            Assert.Contains(495, j.Services[1]?.Container?.Ports);
+            Assert.Contains("my_docker_volume:/volume_mount", j.Services[1]?.Container?.Volumes);
 
-            Assert.Equal("hope", j.Services[2].Container.Credentials.Username);
-            Assert.Equal("1234", j.Services[2].Container.Credentials.Password);
+            Assert.Equal("hope", j.Services[2]?.Container?.Credentials?.Username);
+            Assert.Equal("1234", j.Services[2]?.Container?.Credentials?.Password);
         }
 
         [Fact]
@@ -257,8 +257,8 @@ namespace Sharpliner.Tests.GitHub
 
             // validate that we do have the values and can access them
             Assert.NotNull(j.Strategy);
-            Assert.True(j.Strategy.Configuration?.Keys.Contains("Foo"));
-            Assert.True(j.Strategy.Configuration?.Keys.Contains("Bar"));
+            Assert.True(j.Strategy.Configuration?.ContainsKey("Foo"));
+            Assert.True(j.Strategy.Configuration?.ContainsKey("Bar"));
             Assert.True(j.Strategy.FailFast);
             Assert.Equal(int.MaxValue, j.Strategy.MaxParallel);
         }
@@ -364,9 +364,9 @@ namespace Sharpliner.Tests.GitHub
                 },
             };
 
-            Assert.True(j.Strategy.Exclude[0].Configuration?.Keys.Contains("Foo"));
-            Assert.True(j.Strategy.Exclude[0].Configuration?.Keys.Contains("Bar"));
-            Assert.True(j.Strategy.Exclude[0].Variables?.Keys.Contains("ENV"));
+            Assert.True(j.Strategy.Exclude[0].Configuration?.ContainsKey("Foo"));
+            Assert.True(j.Strategy.Exclude[0].Configuration?.ContainsKey("Bar"));
+            Assert.True(j.Strategy.Exclude[0].Variables?.ContainsKey("ENV"));
         }
     }
 }


### PR DESCRIPTION
- `And()`/`Or()` conditions now accept strings so things `And("succeeded()", IsPullRequest)` is possible
- No more trailing spaces in yaml headers
- Remove `Template<T>()` extension method to force using APIs such as `StepTemplate()`/`JobTemplate()`
- Create full path when publishing pipelines