### PR TITLE
Rename Pipelines to Definitions

### DIFF
--- a/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
@@ -6,7 +6,7 @@ namespace Sharpliner.AzureDevOps;
 /// <summary>
 /// This is a common ancestor for AzDO related definitions (pipelines, templates..) containing useful macros.
 /// </summary>
-public abstract class AzureDevOpsDefinition : PipelineDefinitionBase
+public abstract class AzureDevOpsDefinition : DefinitionBase
 {
     /// <summary>
     /// Start an ${{ if () }} section.
@@ -148,7 +148,7 @@ public abstract class AzureDevOpsDefinition : PipelineDefinitionBase
     /// <param name="pipelineProject">Path to the .csproj where pipelines are defined</param>
     protected static Step ValidateYamlsArePublished(string pipelineProject)
         => Script
-            .Inline($"dotnet build \"{pipelineProject}\" -p:{nameof(PublishPipelines.FailIfChanged)}=true")
+            .Inline($"dotnet build \"{pipelineProject}\" -p:{nameof(PublishDefinitions.FailIfChanged)}=true")
             .DisplayAs("Validate YAML has been published");
 
     /// <summary>

--- a/src/Sharpliner/AzureDevOps/PipelineDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/PipelineDefinition.cs
@@ -3,7 +3,7 @@ namespace Sharpliner.AzureDevOps;
 /// <summary>
 /// Common internal ancestor. Do not inherit from this class, use PipelineDefinition or SingleStagePipelineDefinition.
 /// </summary>
-/// <typeparam name="TPipeline"></typeparam>
+/// <typeparam name="TPipeline">Type of the pipeline (single stage, full..)</typeparam>
 public abstract class PipelineDefinitionBase<TPipeline> : AzureDevOpsDefinition where TPipeline : PipelineBase
 {
     /// <summary>

--- a/src/Sharpliner/DefinitionBase.cs
+++ b/src/Sharpliner/DefinitionBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -9,7 +10,7 @@ namespace Sharpliner;
 /// Common ancestor for all serializable definitions.
 /// Do not override this class, we have a Azure DevOps/GitHub specific child classes for that.
 /// </summary>
-public abstract class PipelineDefinitionBase
+public abstract class DefinitionBase
 {
     /// <summary>
     /// Path to the YAML file where this pipeline will be exported to.
@@ -25,7 +26,7 @@ public abstract class PipelineDefinitionBase
     public virtual TargetPathType TargetPathType => TargetPathType.RelativeToCurrentDir;
 
     // No inheritance outside of this project to not confuse people.
-    internal PipelineDefinitionBase()
+    internal DefinitionBase()
     {
     }
 
@@ -140,13 +141,13 @@ public abstract class PipelineDefinitionBase
     /// </summary>
     protected virtual string[]? Header => new[]
     {
-            string.Empty,
-            "DO NOT MODIFY THIS FILE!",
-            string.Empty,
-            $"This YAML was auto-generated from { GetType().Name }.cs",
-            $"To make changes, change the C# definition and rebuild its project",
-            string.Empty,
-        };
+        string.Empty,
+        "DO NOT MODIFY THIS FILE!",
+        string.Empty,
+        $"This YAML was auto-generated from { GetType().Name }.cs",
+        $"To make changes, change the C# definition and rebuild its project",
+        string.Empty,
+    };
 
     protected static string PrettifyYaml(string yaml)
     {
@@ -158,4 +159,37 @@ public abstract class PipelineDefinitionBase
 
         return yaml;
     }
+}
+
+/// <summary>
+/// Use this data class to create pipeline definitions dynamically inside of PipelineDefinitionCollection.
+/// </summary>
+/// <typeparam name="TDefinition">Type of the definition</typeparam>
+public class DefinitionBase<TDefinition> where TDefinition : DefinitionBase
+{
+    /// <summary>
+    /// If set, override's the target directory set for the parent collection
+    /// </summary>
+    public string? TargetDirectory { get; set; }
+
+    /// <summary>
+    /// If set, override's the target directory set for the parent collection
+    /// 
+    /// Override this to define where the resulting YAML should be stored (together with TargetFile).
+    /// Default is RelativeToCurrentDir.
+    /// </summary>
+    public TargetPathType? TargetPathType { get; set; }
+
+    /// <summary>
+    /// Header that will be shown at the top of the generated YAML file
+    /// 
+    /// Leave null or empty to omit file header.
+    /// </summary>
+    public string[]? Header { get; set; }
+
+    /// <summary>
+    /// The definition itself
+    /// </summary>
+    [DisallowNull]
+    public TDefinition? Definition { get; set; }
 }

--- a/src/Sharpliner/GitHubActions/GitHubActionsPipelineDefinition.cs
+++ b/src/Sharpliner/GitHubActions/GitHubActionsPipelineDefinition.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Inherit from this class to define a GitHub action.
     /// </summary>
-    public abstract class GitHubActionsPipelineDefinition : PipelineDefinitionBase
+    public abstract class GitHubActionsPipelineDefinition : DefinitionBase
     {
         // TODO
     }

--- a/src/Sharpliner/build/Sharpliner.props
+++ b/src/Sharpliner/build/Sharpliner.props
@@ -5,5 +5,5 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
-  <UsingTask TaskName="Sharpliner.PublishPipelines" AssemblyFile="$(TaskAssembly)" />
+  <UsingTask TaskName="Sharpliner.PublishDefinitions" AssemblyFile="$(TaskAssembly)" />
 </Project>

--- a/src/Sharpliner/build/Sharpliner.targets
+++ b/src/Sharpliner/build/Sharpliner.targets
@@ -1,14 +1,16 @@
 <Project>
-  <Target Name="PublishSharplinerPipelines" AfterTargets="Build">
+  <Target Name="PublishSharplinerDefinitions" AfterTargets="Build">
     <PropertyGroup>
       <_AssemblyToSearch>$(OutputPath)$(AssemblyName).dll</_AssemblyToSearch>
       <_FailIfChanged>false</_FailIfChanged>
       <_FailIfChanged Condition="$(FailIfChanged) == 'true'">true</_FailIfChanged>
     </PropertyGroup>
-    <Message Importance="high" Text="Publishing all pipeline definitions inside $(_AssemblyToSearch)" />
 
-    <Error Text="To publish the YAML using Sharpliner please build the project using 'dotnet build' and not from Visual Studio (it needs the .NET Core MSBuild)" Condition=" '$(MSBuildRuntimeType)' != 'Core' " />
+    <Message Importance="high" Text="Publishing all definitions inside $(_AssemblyToSearch)" />
 
-    <PublishPipelines Assembly="$(_AssemblyToSearch)" FailIfChanged="$(_FailIfChanged)" />
+    <Error Text="To publish the YAML using Sharpliner please build the project using 'dotnet build' and not from Visual Studio (it needs the .NET Core MSBuild)"
+           Condition=" '$(MSBuildRuntimeType)' != 'Core' " />
+
+    <PublishDefinitions Assembly="$(_AssemblyToSearch)" FailIfChanged="$(_FailIfChanged)" />
   </Target>
 </Project>


### PR DESCRIPTION
Often, we use the word "Pipelines" but not all objects defined via Sharpliner are pipelines, some are templates and there will be more 

No functional change, just preparing ground for upcoming changes