### PR TITLE
Add missing APIs for condition expressions

### DIFF
--- a/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
@@ -190,6 +190,10 @@ public abstract class AzureDevOpsDefinition
 
     protected static Condition NotIn<T>(string needle, params string[] haystack) => new NotInCondition<T>(needle, haystack);
 
+    protected static Condition Greater<T>(string expression1, string expression2) => new GreaterCondition<T>(expression1, expression2);
+
+    protected static Condition Less<T>(string expression1, string expression2) => new LessCondition<T>(expression1, expression2);
+
     protected static Condition And(params string[] expressions) => new AndCondition(expressions);
 
     protected static Condition Or(params string[] expressions) => new OrCondition(expressions);
@@ -200,7 +204,7 @@ public abstract class AzureDevOpsDefinition
 
     protected static Condition Or(params Condition[] expressions) => new OrCondition(expressions);
 
-    protected static Condition Xor(Condition[] expression1, Condition[] expression2) => new XorCondition(expression1, expression2);
+    protected static Condition Xor(Condition expression1, Condition expression2) => new XorCondition(expression1, expression2);
 
     protected static Condition Contains(string needle, string haystack) => new ContainsCondition(needle, haystack);
 
@@ -217,6 +221,10 @@ public abstract class AzureDevOpsDefinition
     protected static Condition Equal(string expression1, string expression2) => new EqualityCondition(true, expression1, expression2);
 
     protected static Condition NotEqual(string expression1, string expression2) => new EqualityCondition(false, expression1, expression2);
+
+    protected static Condition Greater(string expression1, string expression2) => new GreaterCondition(expression1, expression2);
+
+    protected static Condition Less(string expression1, string expression2) => new LessCondition(expression1, expression2);
 
     protected static Condition IsBranch(string branchName) => new BranchCondition(branchName, true);
 

--- a/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
@@ -174,6 +174,10 @@ public abstract class AzureDevOpsDefinition
 
     protected static Condition<T> NotEqual<T>(string expression1, string expression2) => new EqualityCondition<T>(false, expression1, expression2);
 
+    protected static Condition Contains<T>(string needle, string haystack) => new ContainsCondition<T>(needle, haystack);
+
+    protected static Condition ContainsValue<T>(string needle, params string[] haystack) => new ContainsValueCondition<T>(needle, haystack);
+
     protected static Condition And(string condition1, string condition2) => new AndCondition(condition1, condition2);
 
     protected static Condition Or(string condition1, string condition2) => new OrCondition(condition1, condition2);
@@ -181,6 +185,10 @@ public abstract class AzureDevOpsDefinition
     protected static Condition And(params Condition[] expressions) => new AndCondition(expressions);
 
     protected static Condition Or(params Condition[] expressions) => new OrCondition(expressions);
+
+    protected static Condition Contains(string needle, string haystack) => new ContainsCondition(needle, haystack);
+
+    protected static Condition ContainsValue(string needle, params string[] haystack) => new ContainsValueCondition(needle, haystack);
 
     protected static Condition Equal(string expression1, string expression2) => new EqualityCondition(true, expression1, expression2);
 

--- a/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
@@ -176,7 +176,15 @@ public abstract class AzureDevOpsDefinition
 
     protected static Condition Contains<T>(string needle, string haystack) => new ContainsCondition<T>(needle, haystack);
 
+    protected static Condition StartsWith<T>(string needle, string haystack) => new StartsWithCondition<T>(needle, haystack);
+
+    protected static Condition EndsWith<T>(string needle, string haystack) => new EndsWithCondition<T>(needle, haystack);
+
     protected static Condition ContainsValue<T>(string needle, params string[] haystack) => new ContainsValueCondition<T>(needle, haystack);
+
+    protected static Condition In<T>(string needle, params string[] haystack) => new InCondition<T>(needle, haystack);
+
+    protected static Condition NotIn<T>(string needle, params string[] haystack) => new NotInCondition<T>(needle, haystack);
 
     protected static Condition And(string condition1, string condition2) => new AndCondition(condition1, condition2);
 
@@ -187,6 +195,14 @@ public abstract class AzureDevOpsDefinition
     protected static Condition Or(params Condition[] expressions) => new OrCondition(expressions);
 
     protected static Condition Contains(string needle, string haystack) => new ContainsCondition(needle, haystack);
+
+    protected static Condition StartsWith(string needle, string haystack) => new StartsWithCondition(needle, haystack);
+
+    protected static Condition EndsWith(string needle, string haystack) => new EndsWithCondition(needle, haystack);
+
+    protected static Condition In(string needle, params string[] haystack) => new InCondition(needle, haystack);
+
+    protected static Condition NotIn(string needle, params string[] haystack) => new NotInCondition(needle, haystack);
 
     protected static Condition ContainsValue(string needle, params string[] haystack) => new ContainsValueCondition(needle, haystack);
 

--- a/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
@@ -166,9 +166,13 @@ public abstract class AzureDevOpsDefinition
 
     protected static Condition Or<T>(params string[] expressions) => new OrCondition<T>(expressions);
 
+    protected static Condition Xor<T>(string expression1, string expression2) => new XorCondition<T>(expression1, expression2);
+
     protected static Condition<T> And<T>(params Condition[] expressions) => new AndCondition<T>(expressions);
 
     protected static Condition Or<T>(params Condition[] expressions) => new OrCondition<T>(expressions);
+
+    protected static Condition Xor<T>(Condition expression1, Condition expression2) => new XorCondition<T>(expression1, expression2);
 
     protected static Condition<T> Equal<T>(string expression1, string expression2) => new EqualityCondition<T>(true, expression1, expression2);
 
@@ -186,13 +190,17 @@ public abstract class AzureDevOpsDefinition
 
     protected static Condition NotIn<T>(string needle, params string[] haystack) => new NotInCondition<T>(needle, haystack);
 
-    protected static Condition And(string condition1, string condition2) => new AndCondition(condition1, condition2);
+    protected static Condition And(params string[] expressions) => new AndCondition(expressions);
 
-    protected static Condition Or(string condition1, string condition2) => new OrCondition(condition1, condition2);
+    protected static Condition Or(params string[] expressions) => new OrCondition(expressions);
+
+    protected static Condition Xor(string condition1, string condition2) => new XorCondition(condition1, condition2);
 
     protected static Condition And(params Condition[] expressions) => new AndCondition(expressions);
 
     protected static Condition Or(params Condition[] expressions) => new OrCondition(expressions);
+
+    protected static Condition Xor(Condition[] expression1, Condition[] expression2) => new XorCondition(expression1, expression2);
 
     protected static Condition Contains(string needle, string haystack) => new ContainsCondition(needle, haystack);
 

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/Condition.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/Condition.cs
@@ -156,6 +156,22 @@ public class OrCondition : Condition
     }
 }
 
+public class ContainsCondition : Condition
+{
+    internal ContainsCondition(string needle, string haystack)
+        : base("contains", false, haystack, needle)
+    {
+    }
+}
+
+public class ContainsValueCondition : Condition
+{
+    internal ContainsValueCondition(string needle, params string[] haystack)
+        : base("containsValue", true, haystack.Append(needle))
+    {
+    }
+}
+
 public class CustomCondition<T> : Condition<T>
 {
     public CustomCondition(string condition) : base(condition)
@@ -209,6 +225,23 @@ public class OrCondition<T> : Condition<T>
     {
     }
 }
+
+public class ContainsCondition<T> : Condition<T>
+{
+    internal ContainsCondition(string haystack, string needle)
+        : base("contains", false, haystack, needle)
+    {
+    }
+}
+
+public class ContainsValueCondition<T> : Condition<T>
+{
+    internal ContainsValueCondition(string needle, params string[] haystack)
+        : base("containsValue", true, haystack.Append(needle))
+    {
+    }
+}
+
 public class BranchCondition : EqualityCondition
 {
     internal BranchCondition(string branchName, bool equal)

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/Condition.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/Condition.cs
@@ -156,6 +156,19 @@ public class OrCondition : Condition
     }
 }
 
+public class XorCondition : Condition
+{
+    internal XorCondition(Condition expression1, Condition expression2)
+        : base("xor", true, expression1, expression2)
+    {
+    }
+
+    internal XorCondition(string expression1, string expression2)
+        : base("xor", true, expression1, expression2)
+    {
+    }
+}
+
 public class ContainsCondition : Condition
 {
     internal ContainsCondition(string needle, string haystack)
@@ -254,6 +267,19 @@ public class OrCondition<T> : Condition<T>
 
     internal OrCondition(params string[] expressions)
         : base("or", true, expressions)
+    {
+    }
+}
+
+public class XorCondition<T> : Condition<T>
+{
+    internal XorCondition(Condition expression1, Condition expression2)
+        : base("xor", true, expression1, expression2)
+    {
+    }
+
+    internal XorCondition(string expression1, string expression2)
+        : base("xor", true, expression1, expression2)
     {
     }
 }

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/Condition.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/Condition.cs
@@ -164,6 +164,38 @@ public class ContainsCondition : Condition
     }
 }
 
+public class StartsWithCondition : Condition
+{
+    internal StartsWithCondition(string needle, string haystack)
+        : base("startsWith", false, haystack, needle)
+    {
+    }
+}
+
+public class EndsWithCondition : Condition
+{
+    internal EndsWithCondition(string needle, string haystack)
+        : base("endsWith", false, haystack, needle)
+    {
+    }
+}
+
+public class InCondition : Condition
+{
+    internal InCondition(string needle, params string[] haystack)
+        : base("in", true, haystack.Prepend(needle))
+    {
+    }
+}
+
+public class NotInCondition : Condition
+{
+    internal NotInCondition(string needle, params string[] haystack)
+        : base("notin", true, haystack.Prepend(needle))
+    {
+    }
+}
+
 public class ContainsValueCondition : Condition
 {
     internal ContainsValueCondition(string needle, params string[] haystack)
@@ -234,10 +266,42 @@ public class ContainsCondition<T> : Condition<T>
     }
 }
 
+public class StartsWithCondition<T> : Condition<T>
+{
+    internal StartsWithCondition(string needle, string haystack)
+        : base("startsWith", false, haystack, needle)
+    {
+    }
+}
+
+public class EndsWithCondition<T> : Condition<T>
+{
+    internal EndsWithCondition(string needle, string haystack)
+        : base("endsWith", false, haystack, needle)
+    {
+    }
+}
+
 public class ContainsValueCondition<T> : Condition<T>
 {
     internal ContainsValueCondition(string needle, params string[] haystack)
         : base("containsValue", true, haystack.Append(needle))
+    {
+    }
+}
+
+public class InCondition<T> : Condition<T>
+{
+    internal InCondition(string needle, params string[] haystack)
+        : base("in", true, haystack.Prepend(needle))
+    {
+    }
+}
+
+public class NotInCondition<T> : Condition<T>
+{
+    internal NotInCondition(string needle, params string[] haystack)
+        : base("notin", true, haystack.Prepend(needle))
     {
     }
 }

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/Condition.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/Condition.cs
@@ -204,7 +204,7 @@ public class InCondition : Condition
 public class NotInCondition : Condition
 {
     internal NotInCondition(string needle, params string[] haystack)
-        : base("notin", true, haystack.Prepend(needle))
+        : base("notIn", true, haystack.Prepend(needle))
     {
     }
 }
@@ -213,6 +213,22 @@ public class ContainsValueCondition : Condition
 {
     internal ContainsValueCondition(string needle, params string[] haystack)
         : base("containsValue", true, haystack.Append(needle))
+    {
+    }
+}
+
+public class GreaterCondition : Condition
+{
+    internal GreaterCondition(string first, string second)
+        : base("gt", true, first, second)
+    {
+    }
+}
+
+public class LessCondition : Condition
+{
+    internal LessCondition(string first, string second)
+        : base("lt", true, first, second)
     {
     }
 }
@@ -328,6 +344,22 @@ public class NotInCondition<T> : Condition<T>
 {
     internal NotInCondition(string needle, params string[] haystack)
         : base("notin", true, haystack.Prepend(needle))
+    {
+    }
+}
+
+public class GreaterCondition<T> : Condition<T>
+{
+    internal GreaterCondition(string first, string second)
+        : base("gt", true, first, second)
+    {
+    }
+}
+
+public class LessCondition<T> : Condition<T>
+{
+    internal LessCondition(string first, string second)
+        : base("lt", true, first, second)
     {
     }
 }

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/ConditionBuilder.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/ConditionBuilder.cs
@@ -50,6 +50,12 @@ public class ConditionBuilder
     public Condition ContainsValue(string needle, params string[] haystack)
         => new ContainsValueCondition(needle, haystack);
 
+    public Condition In(string needle, string haystack)
+        => new InCondition(needle, haystack);
+
+    public Condition NotIn(string needle, params string[] haystack)
+        => new NotInCondition(needle, haystack);
+
     public Condition IsBranch(string branchName)
         => Link(new BranchCondition(branchName, true));
 
@@ -101,6 +107,12 @@ public class ConditionBuilder<T>
 
     public Condition<T> Contains(string needle, string haystack)
         => new ContainsCondition<T>(needle, haystack);
+
+    public Condition In(string needle, string haystack)
+        => new InCondition<T>(needle, haystack);
+
+    public Condition NotIn(string needle, params string[] haystack)
+        => new NotInCondition<T>(needle, haystack);
 
     public Condition<T> ContainsValue(string needle, params string[] haystack)
         => new ContainsValueCondition<T>(needle, haystack);

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/ConditionBuilder.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/ConditionBuilder.cs
@@ -62,6 +62,12 @@ public class ConditionBuilder
     public Condition NotIn(string needle, params string[] haystack)
         => new NotInCondition(needle, haystack);
 
+    public Condition Greater(string first, string second)
+        => Link(new GreaterCondition(first, second));
+
+    public Condition Less(string first, string second)
+        => Link(new LessCondition(first, second));
+
     public Condition IsBranch(string branchName)
         => Link(new BranchCondition(branchName, true));
 
@@ -134,6 +140,12 @@ public class ConditionBuilder<T>
 
     public Condition<T> IsNotBranch(string branchName)
         => Link(new BranchCondition<T>(branchName, false));
+
+    public Condition<T> Greater(string first, string second)
+        => Link(new GreaterCondition<T>(first, second));
+
+    public Condition<T> Less(string first, string second)
+        => Link(new LessCondition<T>(first, second));
 
     public Condition<T> IsPullRequest
         => Link(new BuildReasonCondition<T>("'PullRequest'", true));

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/ConditionBuilder.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/ConditionBuilder.cs
@@ -44,6 +44,12 @@ public class ConditionBuilder
     public Condition Or(params string[] expressions)
         => Link(new OrCondition(expressions));
 
+    public Condition Xor(Condition expression1, Condition expression2)
+        => Link(new XorCondition(expression1, expression2));
+
+    public Condition Xor(string expression1, string expression2)
+        => Link(new XorCondition(expression1, expression2));
+
     public Condition Contains(string needle, string haystack)
         => new ContainsCondition(needle, haystack);
 
@@ -98,6 +104,12 @@ public class ConditionBuilder<T>
 
     public Condition<T> Or(params Condition[] expressions)
         => Link(new OrCondition<T>(expressions));
+
+    public Condition<T> Xor(Condition expression1, Condition expression2)
+        => Link(new XorCondition<T>(expression1, expression2));
+
+    public Condition<T> Xor(string expression1, string expression2)
+        => Link(new XorCondition<T>(expression1, expression2));
 
     public Condition<T> And(params string[] expressions)
         => Link(new AndCondition<T>(expressions));

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/ConditionBuilder.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/ConditionBuilder.cs
@@ -44,6 +44,12 @@ public class ConditionBuilder
     public Condition Or(params string[] expressions)
         => Link(new OrCondition(expressions));
 
+    public Condition Contains(string needle, string haystack)
+        => new ContainsCondition(needle, haystack);
+
+    public Condition ContainsValue(string needle, params string[] haystack)
+        => new ContainsValueCondition(needle, haystack);
+
     public Condition IsBranch(string branchName)
         => Link(new BranchCondition(branchName, true));
 
@@ -92,6 +98,12 @@ public class ConditionBuilder<T>
 
     public Condition<T> Or(params string[] expressions)
         => Link(new OrCondition<T>(expressions));
+
+    public Condition<T> Contains(string needle, string haystack)
+        => new ContainsCondition<T>(needle, haystack);
+
+    public Condition<T> ContainsValue(string needle, params string[] haystack)
+        => new ContainsValueCondition<T>(needle, haystack);
 
     public Condition<T> IsBranch(string branchName)
         => Link(new BranchCondition<T>(branchName, true));

--- a/tests/Sharpliner.Tests/AzureDevOps/ConditionedExpressions/ConditionalsTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/ConditionedExpressions/ConditionalsTests.cs
@@ -14,7 +14,7 @@ public class ConditionalsTests
             Variables =
             {
                 If.And(
-                    IsBranch("production"),
+                    NotIn("'bar'", "'foo'", "'xyz'", "'foo'"),
                     NotEqual(variables["Configuration"], "'Debug'"),
                     "containsValue($(System.User), 'azdobot')")
                     .Variable("TargetBranch", "$(System.PullRequest.SourceBranch)"),
@@ -29,7 +29,7 @@ public class ConditionalsTests
         var variable = pipeline.Pipeline.Variables.First();
         variable.Condition.Should().Be(
             "and(" +
-                "eq(variables['Build.SourceBranch'], 'refs/heads/production'), " +
+                "notIn('bar', 'foo', 'xyz', 'foo'), " +
                 "ne(variables['Configuration'], 'Debug'), " +
                 "containsValue($(System.User), 'azdobot'))");
     }
@@ -42,7 +42,7 @@ public class ConditionalsTests
             {
                 If.Or(
                     And(
-                        NotEqual("true", "true"),
+                        Less("5", "3"),
                         Equal(variables["Build.SourceBranch"], "'refs/heads/production'"),
                         IsBranch("release")),
                     NotEqual(variables["Configuration"], "'Debug'"),
@@ -60,7 +60,7 @@ public class ConditionalsTests
         variable.Condition.Should().Be(
             "or(" +
                 "and(" +
-                    "ne(true, true), " +
+                    "lt(5, 3), " +
                     "eq(variables['Build.SourceBranch'], 'refs/heads/production'), " +
                     "eq(variables['Build.SourceBranch'], 'refs/heads/release')), " +
                 "ne(variables['Configuration'], 'Debug'), " +
@@ -107,7 +107,7 @@ public class ConditionalsTests
                     .Variable("feature", "off")
                     .Variable("feature2", "off"),
 
-                If.NotEqual("c", "d")
+                If.ContainsValue("'foo'", "'bar'", "'foo'", "'xyz'")
                     .Variable("feature", "on")
                     .Variable("feature2", "on")
                     .If.And(Equal("e", "f"), NotEqual("g", "h"))
@@ -140,7 +140,7 @@ public class ConditionalsTests
   - name: feature2
     value: off
 
-- ${{ if ne(c, d) }}:
+- ${{ if containsValue('bar', 'foo', 'xyz', 'foo') }}:
   - name: feature
     value: on
 
@@ -247,10 +247,10 @@ public class ConditionalsTests
                 If.Condition("containsValue($(System.User), 'azdobot')")
                     .Variable("TargetBranch", "$(System.PullRequest.SourceBranch)"),
 
-                If.Condition(Condition("in('foo', 'bar'))"))
+                If.Condition(In("'foo'", "'bar'"))
                     .Variable("TargetBranch", "production"),
 
-                If.Condition(IsPullRequest)
+                If.Condition(Xor("True", "$(Variable)"))
                     .Variable("TargetBranch", "main"),
             }
         };
@@ -263,8 +263,8 @@ public class ConditionalsTests
         var variable = pipeline.Pipeline.Variables.First();
         variable.Condition.Should().Be("containsValue($(System.User), 'azdobot')");
         variable = pipeline.Pipeline.Variables.ElementAt(1);
-        variable.Condition.Should().Be("in('foo', 'bar'))");
+        variable.Condition.Should().Be("in('foo', 'bar')");
         variable = pipeline.Pipeline.Variables.Last();
-        variable.Condition.Should().Be("eq(variables['Build.Reason'], 'PullRequest')");
+        variable.Condition.Should().Be("xor(True, $(Variable))");
     }
 }


### PR DESCRIPTION
Implements APIs for following expressions:
- `startsWith`, `endsWith`, `in`, `notIn`, `contains`, `containsValue`, `xor`, `lt`, `gt`