### PR TITLE
Enable adding items instead of a full library too

### DIFF
--- a/docs/AzureDevOps/DefinitionLibraries.md
+++ b/docs/AzureDevOps/DefinitionLibraries.md
@@ -87,3 +87,22 @@ Then you can use this library for different projects easily:
     }
 ...
 ```
+
+Furthermore, you can also pass a list of items to the methods that reference libraries and get those expanded without the need to declare a new library class.
+This gives you quite a bit flexibility when dealing with repetitive patterns:
+
+```csharp
+...
+    new Job("Build")
+    {
+        Steps =
+        {
+            Script.Inline("echo 'Hello World'"),
+
+            ExpandSteps(new[] { "5.0.403", "6.0.100" }.Select(version => DotNet.Install.Sdk(version))),
+
+            Script.Inline("echo 'Goodbye World'"),
+        }
+    }
+...
+```

--- a/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Sharpliner.AzureDevOps.ConditionedExpressions;
 using Sharpliner.AzureDevOps.Tasks;
 
@@ -69,6 +71,102 @@ public abstract class AzureDevOpsDefinition
     /// </summary>
     protected static Conditioned<VariableBase> VariableLibrary(VariableLibrary library)
         => new LibraryReference<VariableBase>(library);
+
+    /// <summary>
+    /// Reference a step library (series of library stages).
+    /// </summary>
+    protected static Conditioned<Stage> ExpandStages(params Conditioned<Stage>[] stages)
+        => new LibraryReference<Stage>(stages);
+
+    /// <summary>
+    /// Reference a step library (series of library jobs).
+    /// </summary>
+    protected static Conditioned<Job> ExpandJobs(params Conditioned<Job>[] jobs)
+        => new LibraryReference<Job>(jobs);
+
+    /// <summary>
+    /// Reference a step library (series of library steps).
+    /// </summary>
+    protected static Conditioned<Step> ExpandSteps(params Conditioned<Step>[] steps)
+        => new LibraryReference<Step>(steps);
+
+    /// <summary>
+    /// Reference a step library (series of library variables).
+    /// </summary>
+    protected static Conditioned<VariableBase> ExpandVariables(params Conditioned<VariableBase>[] variables)
+        => new LibraryReference<VariableBase>(variables);
+
+    /// <summary>
+    /// Reference a step library (series of library stages).
+    /// </summary>
+    protected static Conditioned<Stage> ExpandStages(IEnumerable<Conditioned<Stage>> stages)
+        => new LibraryReference<Stage>(stages);
+
+    /// <summary>
+    /// Reference a step library (series of library jobs).
+    /// </summary>
+    protected static Conditioned<Job> ExpandJobs(IEnumerable<Conditioned<Job>> jobs)
+        => new LibraryReference<Job>(jobs);
+
+    /// <summary>
+    /// Reference a step library (series of library steps).
+    /// </summary>
+    protected static Conditioned<Step> ExpandSteps(IEnumerable<Conditioned<Step>> steps)
+        => new LibraryReference<Step>(steps);
+
+    /// <summary>
+    /// Reference a step library (series of library variables).
+    /// </summary>
+    protected static Conditioned<VariableBase> ExpandVariables(IEnumerable<Conditioned<VariableBase>> variables)
+        => new LibraryReference<VariableBase>(variables);
+
+    /// <summary>
+    /// Reference a step library (series of library stages).
+    /// </summary>
+    protected static Conditioned<Stage> ExpandStages(params Stage[] stages)
+        => ExpandStages(stages.Select(x => new Conditioned<Stage>(x)));
+
+    /// <summary>
+    /// Reference a step library (series of library jobs).
+    /// </summary>
+    protected static Conditioned<Job> ExpandJobs(params Job[] jobs)
+        => ExpandJobs(jobs.Select(x => new Conditioned<Job>(x)));
+
+    /// <summary>
+    /// Reference a step library (series of library steps).
+    /// </summary>
+    protected static Conditioned<Step> ExpandSteps(params Step[] steps)
+        => ExpandSteps(steps.Select(x => new Conditioned<Step>(x)));
+
+    /// <summary>
+    /// Reference a step library (series of library variables).
+    /// </summary>
+    protected static Conditioned<VariableBase> ExpandVariables(params VariableBase[] variables)
+        => ExpandVariables(variables.Select(x => new Conditioned<VariableBase>(x)));
+
+    /// <summary>
+    /// Reference a step library (series of library stages).
+    /// </summary>
+    protected static Conditioned<Stage> ExpandStages(IEnumerable<Stage> stages)
+        => ExpandStages(stages.ToArray());
+
+    /// <summary>
+    /// Reference a step library (series of library jobs).
+    /// </summary>
+    protected static Conditioned<Job> ExpandJobs(IEnumerable<Job> jobs)
+        => ExpandJobs(jobs.ToArray());
+
+    /// <summary>
+    /// Reference a step library (series of library steps).
+    /// </summary>
+    protected static Conditioned<Step> ExpandSteps(IEnumerable<Step> steps)
+        => ExpandSteps(steps.ToArray());
+
+    /// <summary>
+    /// Reference a step library (series of library variables).
+    /// </summary>
+    protected static Conditioned<VariableBase> ExpandVariables(IEnumerable<VariableBase> variables)
+        => ExpandVariables(variables.ToArray());
 
     /// <summary>
     /// Reference a stage library (series of library stages).

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/ConditionExtensions.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/ConditionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Sharpliner.AzureDevOps.ConditionedExpressions;
 
 namespace Sharpliner.AzureDevOps;
@@ -161,13 +162,13 @@ public static class ConditionExtensions
         => Conditioned.Link(condition, new Template<VariableBase>(condition: condition.ToString(), path: path, parameters ?? new TemplateParameters()));
 
     /// <summary>
-    /// Reference a step library (series of library stages).
+    /// Reference a stage library (series of library stages).
     /// </summary>
     public static Conditioned<Stage> StageLibrary(this Condition condition, StageLibrary library)
         => Conditioned.Link(condition, library.Items);
 
     /// <summary>
-    /// Reference a step library (series of library jobs).
+    /// Reference a job library (series of library jobs).
     /// </summary>
     public static Conditioned<Job> JobLibrary(this Condition condition, JobLibrary library)
         => Conditioned.Link(condition, library.Items);
@@ -179,7 +180,7 @@ public static class ConditionExtensions
         => Conditioned.Link(condition, library.Items);
 
     /// <summary>
-    /// Reference a step library (series of library Variables).
+    /// Reference a variable library (series of library Variables).
     /// </summary>
     public static Conditioned<VariableBase> VariableLibrary(this Condition condition, VariableLibrary library)
         => Conditioned.Link(condition, library.Items);
@@ -211,6 +212,102 @@ public static class ConditionExtensions
     public static Conditioned<VariableBase> VariableLibrary<T>(this Condition condition)
         where T : VariableLibrary, new()
         => Conditioned.Link(condition, AzureDevOpsDefinition.CreateInstance<T>().Items);
+
+    /// <summary>
+    /// Include a set of stages.
+    /// </summary>
+    public static Conditioned<Stage> Stages(this Condition condition, params Conditioned<Stage>[] stages)
+        => Conditioned.Link<Stage>(condition, stages);
+
+    /// <summary>
+    /// Include a set of jobs.
+    /// </summary>
+    public static Conditioned<Job> Jobs(this Condition condition, params Conditioned<Job>[] jobs)
+        => Conditioned.Link<Job>(condition, jobs);
+
+    /// <summary>
+    /// Include a set of steps.
+    /// </summary>
+    public static Conditioned<Step> Steps(this Condition condition, params Conditioned<Step>[] steps)
+        => Conditioned.Link<Step>(condition, steps);
+
+    /// <summary>
+    /// Include a set of variables.
+    /// </summary>
+    public static Conditioned<VariableBase> Variables(this Condition condition, params Conditioned<VariableBase>[] variables)
+        => Conditioned.Link<VariableBase>(condition, variables);
+
+    /// <summary>
+    /// Include a set of stages.
+    /// </summary>
+    public static Conditioned<Stage> Stages(this Condition condition, IEnumerable<Conditioned<Stage>> stages)
+        => Conditioned.Link(condition, stages);
+
+    /// <summary>
+    /// Include a set of jobs.
+    /// </summary>
+    public static Conditioned<Job> Jobs(this Condition condition, IEnumerable<Conditioned<Job>> jobs)
+        => Conditioned.Link(condition, jobs);
+
+    /// <summary>
+    /// Include a set of steps.
+    /// </summary>
+    public static Conditioned<Step> Steps(this Condition condition, IEnumerable<Conditioned<Step>> steps)
+        => Conditioned.Link(condition, steps);
+
+    /// <summary>
+    /// Include a set of variables.
+    /// </summary>
+    public static Conditioned<VariableBase> Variables(this Condition condition, IEnumerable<Conditioned<VariableBase>> variables)
+        => Conditioned.Link(condition, variables);
+
+    /// <summary>
+    /// Include a set of stages.
+    /// </summary>
+    public static Conditioned<Stage> Stages(this Condition condition, params Stage[] stages)
+        => Conditioned.Link<Stage>(condition, stages.Select(x => new Conditioned<Stage>(x)));
+
+    /// <summary>
+    /// Include a set of jobs.
+    /// </summary>
+    public static Conditioned<Job> Jobs(this Condition condition, params Job[] jobs)
+        => Conditioned.Link<Job>(condition, jobs.Select(x => new Conditioned<Job>(x)));
+
+    /// <summary>
+    /// Include a set of steps.
+    /// </summary>
+    public static Conditioned<Step> Steps(this Condition condition, params Step[] steps)
+        => Conditioned.Link<Step>(condition, steps.Select(x => new Conditioned<Step>(x)));
+
+    /// <summary>
+    /// Include a set of variables.
+    /// </summary>
+    public static Conditioned<VariableBase> Variables(this Condition condition, params VariableBase[] variables)
+        => Conditioned.Link<VariableBase>(condition, variables.Select(x => new Conditioned<VariableBase>(x)));
+
+    /// <summary>
+    /// Include a set of stages.
+    /// </summary>
+    public static Conditioned<Stage> Stages(this Condition condition, IEnumerable<Stage> stages)
+        => condition.Stages(stages.ToArray());
+
+    /// <summary>
+    /// Include a set of jobs.
+    /// </summary>
+    public static Conditioned<Job> Jobs(this Condition condition, IEnumerable<Job> jobs)
+        => condition.Jobs(jobs.ToArray());
+
+    /// <summary>
+    /// Include a set of steps.
+    /// </summary>
+    public static Conditioned<Step> Steps(this Condition condition, IEnumerable<Step> steps)
+        => condition.Steps(steps.ToArray());
+
+    /// <summary>
+    /// Include a set of variables.
+    /// </summary>
+    public static Conditioned<VariableBase> Variables(this Condition condition, IEnumerable<VariableBase> variables)
+        => condition.Variables(variables.ToArray());
 
     public static Conditioned<Strategy> Strategy(this Condition condition, Strategy strategy)
         => Conditioned.Link(condition, strategy);

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/Conditioned.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/Conditioned.cs
@@ -80,12 +80,12 @@ public abstract record Conditioned : IYamlConvertible
     /// This method is used for double-linking of the definition expression tree.
     /// </summary>
     /// <param name="condition">Parent condition</param>
-    /// <param name="libraryItems">Library items to add to a condition</param>
+    /// <param name="items">Items to add to a condition</param>
     /// <returns>The conditioned definition coming out of the inputs</returns>
-    internal static Conditioned<T> Link<T>(Condition condition, IEnumerable<Conditioned<T>> libraryItems)
+    internal static Conditioned<T> Link<T>(Condition condition, IEnumerable<Conditioned<T>> items)
     {
         var conditionedDefinition = new Conditioned<T>(default!, condition.ToString());
-        conditionedDefinition.Definitions.AddRange(libraryItems);
+        conditionedDefinition.Definitions.AddRange(items);
         condition.Parent?.Definitions.Add(conditionedDefinition);
         conditionedDefinition.Parent = condition.Parent;
         return conditionedDefinition;

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/ConditionedExtensions.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/ConditionedExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Sharpliner.AzureDevOps.ConditionedExpressions;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Sharpliner.AzureDevOps.ConditionedExpressions;
 
 namespace Sharpliner.AzureDevOps;
 
@@ -231,6 +233,158 @@ public static class ConditionedExtensions
         conditionedDefinition.Definitions.Add(new LibraryReference<VariableBase>(library));
         return conditionedDefinition;
     }
+
+    /// <summary>
+    /// Include a set of steps.
+    /// </summary>
+    public static Conditioned<Stage> Stages(
+        this Conditioned<Stage> conditionedDefinition,
+        IEnumerable<Conditioned<Stage>> stages)
+    {
+        conditionedDefinition.Definitions.Add(new LibraryReference<Stage>(stages));
+        return conditionedDefinition;
+    }
+
+    /// <summary>
+    /// Include a set of steps.
+    /// </summary>
+    public static Conditioned<Job> Jobs(
+        this Conditioned<Job> conditionedDefinition,
+        IEnumerable<Conditioned<Job>> jobs)
+    {
+        conditionedDefinition.Definitions.Add(new LibraryReference<Job>(jobs));
+        return conditionedDefinition;
+    }
+
+    /// <summary>
+    /// Include a set of steps.
+    /// </summary>
+    public static Conditioned<Step> Steps(
+        this Conditioned<Step> conditionedDefinition,
+        IEnumerable<Conditioned<Step>> steps)
+    {
+        conditionedDefinition.Definitions.Add(new LibraryReference<Step>(steps));
+        return conditionedDefinition;
+    }
+
+    /// <summary>
+    /// Include a set of steps.
+    /// </summary>
+    public static Conditioned<VariableBase> Variables(
+        this Conditioned<VariableBase> conditionedDefinition,
+        IEnumerable<Conditioned<VariableBase>> variables)
+    {
+        conditionedDefinition.Definitions.Add(new LibraryReference<VariableBase>(variables));
+        return conditionedDefinition;
+    }
+
+    /// <summary>
+    /// Include a set of steps.
+    /// </summary>
+    public static Conditioned<Stage> Stages(
+        this Conditioned<Stage> conditionedDefinition,
+        params Conditioned<Stage>[] stages)
+    {
+        conditionedDefinition.Definitions.Add(new LibraryReference<Stage>(stages));
+        return conditionedDefinition;
+    }
+
+    /// <summary>
+    /// Include a set of steps.
+    /// </summary>
+    public static Conditioned<Job> Jobs(
+        this Conditioned<Job> conditionedDefinition,
+        params Conditioned<Job>[] jobs)
+    {
+        conditionedDefinition.Definitions.Add(new LibraryReference<Job>(jobs));
+        return conditionedDefinition;
+    }
+
+    /// <summary>
+    /// Include a set of steps.
+    /// </summary>
+    public static Conditioned<Step> Steps(
+        this Conditioned<Step> conditionedDefinition,
+        params Conditioned<Step>[] steps)
+    {
+        conditionedDefinition.Definitions.Add(new LibraryReference<Step>(steps));
+        return conditionedDefinition;
+    }
+
+    /// <summary>
+    /// Include a set of steps.
+    /// </summary>
+    public static Conditioned<VariableBase> Variables(
+        this Conditioned<VariableBase> conditionedDefinition,
+        params Conditioned<VariableBase>[] variables)
+    {
+        conditionedDefinition.Definitions.Add(new LibraryReference<VariableBase>(variables));
+        return conditionedDefinition;
+    }
+
+    /// <summary>
+    /// Include a set of steps.
+    /// </summary>
+    public static Conditioned<Stage> Stages(
+        this Conditioned<Stage> conditionedDefinition,
+        IEnumerable<Stage> stages)
+        => conditionedDefinition.Stages(stages.ToArray());
+
+    /// <summary>
+    /// Include a set of steps.
+    /// </summary>
+    public static Conditioned<Job> Jobs(
+        this Conditioned<Job> conditionedDefinition,
+        IEnumerable<Job> jobs)
+        => conditionedDefinition.Jobs(jobs.ToArray());
+
+    /// <summary>
+    /// Include a set of steps.
+    /// </summary>
+    public static Conditioned<Step> Steps(
+        this Conditioned<Step> conditionedDefinition,
+        IEnumerable<Step> steps)
+        => conditionedDefinition.Steps(steps.ToArray());
+
+    /// <summary>
+    /// Include a set of steps.
+    /// </summary>
+    public static Conditioned<VariableBase> Variables(
+        this Conditioned<VariableBase> conditionedDefinition,
+        IEnumerable<VariableBase> variables)
+        => conditionedDefinition.Variables(variables.ToArray());
+
+    /// <summary>
+    /// Include a set of steps.
+    /// </summary>
+    public static Conditioned<Stage> Stages(
+        this Conditioned<Stage> conditionedDefinition,
+        params Stage[] stages)
+        => conditionedDefinition.Stages(stages.Select(x => new Conditioned<Stage>(x)));
+
+    /// <summary>
+    /// Include a set of steps.
+    /// </summary>
+    public static Conditioned<Job> Jobs(
+        this Conditioned<Job> conditionedDefinition,
+        params Job[] jobs)
+        => conditionedDefinition.Jobs(jobs.Select(x => new Conditioned<Job>(x)));
+
+    /// <summary>
+    /// Include a set of steps.
+    /// </summary>
+    public static Conditioned<Step> Steps(
+        this Conditioned<Step> conditionedDefinition,
+        params Step[] steps)
+        => conditionedDefinition.Steps(steps.Select(x => new Conditioned<Step>(x)));
+
+    /// <summary>
+    /// Include a set of steps.
+    /// </summary>
+    public static Conditioned<VariableBase> Variables(
+        this Conditioned<VariableBase> conditionedDefinition,
+        params VariableBase[] variables)
+        => conditionedDefinition.Variables(variables.Select(x => new Conditioned<VariableBase>(x)));
 
     /// <summary>
     /// Reference a step library (series of library stages).

--- a/src/Sharpliner/AzureDevOps/DefinitionLibrary.cs
+++ b/src/Sharpliner/AzureDevOps/DefinitionLibrary.cs
@@ -31,6 +31,11 @@ public record LibraryReference<T> : Conditioned<T>
         Items = library.Items;
     }
 
+    public LibraryReference(IEnumerable<Conditioned<T>> items) : base()
+    {
+        Items = items;
+    }
+
     protected override void SerializeSelf(IEmitter emitter, ObjectSerializer nestedObjectSerializer)
     {
         foreach (var item in Items)


### PR DESCRIPTION
You can also pass a list of items to the methods that reference libraries and get those expanded without the need to declare a new library class.

```csharp
...
    new Job("Build")
    {
        Steps =
        {
            Script.Inline("echo 'Hello World'"),

            ExpandSteps(new[] { "5.0.403", "6.0.100" }.Select(version => DotNet.Install.Sdk(version))),

            Script.Inline("echo 'Goodbye World'"),
        }
    }
...
```