### PR TITLE
[AzureDevOps] Fix YAML property `schedule` to `schedules`

### DIFF
--- a/src/Sharpliner/AzureDevOps/Pipeline.cs
+++ b/src/Sharpliner/AzureDevOps/Pipeline.cs
@@ -48,7 +48,7 @@ public abstract record PipelineBase
     /// </summary>
     [YamlMember(Order = 350)]
     [DisallowNull]
-    public List<ScheduledTrigger> Schedule { get; init; } = new();
+    public List<ScheduledTrigger> Schedules { get; init; } = new();
 
     /// <summary>
     /// A resource is any external service that is consumed as part of your pipeline

--- a/tests/Sharpliner.Tests/AzureDevOps/Model/TriggerSerializationTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/Model/TriggerSerializationTests.cs
@@ -25,7 +25,7 @@ public class TriggerSerializationTests
                 }
             },
 
-            Schedule =
+            Schedules =
             {
                 new("0 0 24 * *", "staging", "production")
                 {
@@ -59,7 +59,7 @@ pr:
     - main
     - develop
 
-schedule:
+schedules:
 - cron: 0 0 24 * *
   displayName: Releases
   branches:


### PR DESCRIPTION
Fixes #162 