### PR TITLE
Fix PowerShell and Bash tasks when referencing script files

### DIFF
--- a/src/Sharpliner/AzureDevOps/Model/Tasks/AzureDevOpsTask.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/AzureDevOpsTask.cs
@@ -1,4 +1,5 @@
-﻿using Sharpliner.AzureDevOps.ConditionedExpressions;
+﻿using System;
+using Sharpliner.AzureDevOps.ConditionedExpressions;
 using YamlDotNet.Serialization;
 
 namespace Sharpliner.AzureDevOps.Tasks;
@@ -45,7 +46,19 @@ public record AzureDevOpsTask : Step
     {
         if (string.IsNullOrEmpty(task))
         {
-            throw new System.ArgumentException($"'{nameof(task)}' cannot be null or empty.", nameof(task));
+            throw new ArgumentException($"'{nameof(task)}' cannot be null or empty.", nameof(task));
+        }
+
+        Task = task;
+    }
+
+    // This is intended for cases where we need to copy some other task as its full AzureDevOpsTask version
+    internal AzureDevOpsTask(string task, Step original)
+        : base(original)
+    {
+        if (string.IsNullOrEmpty(task))
+        {
+            throw new ArgumentException($"'{nameof(task)}' cannot be null or empty.", nameof(task));
         }
 
         Task = task;

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/BashTask.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/BashTask.cs
@@ -66,8 +66,6 @@ public record BashFileTask : BashTask, IYamlConvertible
     /// </summary>
     public string FilePath { get; }
 
-    public string TargetType => "filePath";
-
     /// <summary>
     /// Arguments passed to the Bash script.
     /// </summary>
@@ -108,12 +106,14 @@ public record BashFileTask : BashTask, IYamlConvertible
             }
         }
 
-        Add("targetType", TargetType, null);
+        var defaultValue = new BashFileTask(string.Empty);
+
+        Add("targetType", "filePath", null);
         Add("filePath", FilePath, null);
-        Add("arguments", Arguments, null);
-        Add("workingDirectory", WorkingDirectory, null);
-        Add("failOnStderr", FailOnStderr, false);
-        Add("bashEnvValue", BashEnv, null);
+        Add("arguments", Arguments, defaultValue.Arguments);
+        Add("workingDirectory", WorkingDirectory, defaultValue.WorkingDirectory);
+        Add("failOnStderr", FailOnStderr, defaultValue.FailOnStderr);
+        Add("bashEnvValue", BashEnv, defaultValue.BashEnv);
 
         nestedObjectSerializer(new AzureDevOpsTask("Bash@3", this)
         {

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/BashTask.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/BashTask.cs
@@ -58,22 +58,66 @@ public record InlineBashTask : BashTask
     }
 }
 
-public record BashFileTask : BashTask
+public record BashFileTask : BashTask, IYamlConvertible
 {
     /// <summary>
     /// Path of the script to execute.
     /// Must be a fully qualified path or relative to $(System.DefaultWorkingDirectory).
     /// </summary>
-    [YamlMember(Alias = "bash", Order = 1)]
     public string FilePath { get; }
+
+    public string TargetType => "filePath";
 
     /// <summary>
     /// Arguments passed to the Bash script.
     /// </summary>
     public string? Arguments { get; init; }
 
+    /// <summary>
+    /// If the related input is specified, the value will be used as the path of a startup file
+    /// that will be executed before running the script.
+    ///
+    /// If the environment variable BASH_ENV has already been defined, the task will override
+    /// this variable only for the current task.
+    /// </summary>
+    public string? BashEnv { get; init; }
+
     public BashFileTask(string filePath)
     {
         FilePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+    }
+
+    public void Read(IParser parser, Type expectedType, ObjectDeserializer nestedObjectDeserializer)
+        => throw new NotImplementedException();
+
+    // This is unfortunately needed because when referencing a script file, the "powershell: ..." variant does not work
+    public void Write(IEmitter emitter, ObjectSerializer nestedObjectSerializer)
+    {
+        var inputs = new TaskInputs();
+
+        void Add(string key, object? value, object? defaultValue)
+        {
+            if (value is null)
+            {
+                return;
+            }
+
+            if (!value.Equals(defaultValue))
+            {
+                inputs![key] = value;
+            }
+        }
+
+        Add("targetType", TargetType, null);
+        Add("filePath", FilePath, null);
+        Add("arguments", Arguments, null);
+        Add("workingDirectory", WorkingDirectory, null);
+        Add("failOnStderr", FailOnStderr, false);
+        Add("bashEnvValue", BashEnv, null);
+
+        nestedObjectSerializer(new AzureDevOpsTask("Bash@3", this)
+        {
+            Inputs = inputs
+        });
     }
 }

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/PowerShellTask.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/PowerShellTask.cs
@@ -19,15 +19,47 @@ public abstract record PowershellTask : Step
     /// Default value: `stop`.
     /// </summary>
     [YamlMember(Order = 114)]
-    [DefaultValue(ErrorActionPreference.Stop)]
-    public ErrorActionPreference ErrorActionPreference { get; init; } = ErrorActionPreference.Stop;
+    [DefaultValue(ActionPreference.Stop)]
+    public ActionPreference ErrorActionPreference { get; init; } = ActionPreference.Stop;
+
+    /// <summary>
+    /// Prepends the line $WarningPreference = 'VALUE' at the top of your script.
+    /// Default value: `continue`.
+    /// </summary>
+    [YamlMember(Order = 114)]
+    [DefaultValue(ActionPreference.Continue)]
+    public ActionPreference WarningPreference { get; init; } = ActionPreference.Continue;
+
+    /// <summary>
+    /// Prepends the line $InformationPreference = 'VALUE' at the top of your script.
+    /// Default value: `continue`.
+    /// </summary>
+    [YamlMember(Order = 114)]
+    [DefaultValue(ActionPreference.Continue)]
+    public ActionPreference InformationPreference { get; init; } = ActionPreference.Continue;
+
+    /// <summary>
+    /// Prepends the line $VerbosePreference = 'VALUE' at the top of your script.
+    /// Default value: `continue`.
+    /// </summary>
+    [YamlMember(Order = 114)]
+    [DefaultValue(ActionPreference.Continue)]
+    public ActionPreference VerbosePreference { get; init; } = ActionPreference.Continue;
+
+    /// <summary>
+    /// Prepends the line $DebugPreference = 'VALUE' at the top of your script.
+    /// Default value: `continue`.
+    /// </summary>
+    [YamlMember(Order = 114)]
+    [DefaultValue(ActionPreference.Continue)]
+    public ActionPreference DebugPreference { get; init; } = ActionPreference.Continue;
 
     /// <summary>
     /// If this is true, this task will fail if any errors are written to the error pipeline, or if any data is written to the Standard Error stream.
     /// Otherwise the task will rely on the exit code to determine failure
     /// Default value: `false`.
     /// </summary>
-    [YamlMember(Order = 115)]
+    [YamlMember(Order = 125)]
     public bool FailOnStderr { get; init; } = false;
 
     /// <summary>
@@ -36,14 +68,14 @@ public abstract record PowershellTask : Step
     /// Otherwise the line is not appended to the end of your script
     /// Default value: `false`.
     /// </summary>
-    [YamlMember(Order = 116)]
+    [YamlMember(Order = 126)]
     public bool IgnoreLASTEXITCODE { get; init; } = false;
 
     /// <summary>
     /// If this is true, then on Windows the task will use pwsh.exe from your PATH instead of powershell.exe.
     /// Default value: `false`.
     /// </summary>
-    [YamlMember(Order = 117)]
+    [YamlMember(Order = 127)]
     public bool Pwsh { get; init; } = false;
 }
 
@@ -89,7 +121,7 @@ public record PowershellFileTask : PowershellTask
     }
 }
 
-public enum ErrorActionPreference
+public enum ActionPreference
 {
     /// <summary>
     /// (Default) Displays the error message and continues executing.

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/PowerShellTask.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/PowerShellTask.cs
@@ -105,8 +105,6 @@ public record PowershellFileTask : PowershellTask, IYamlConvertible
     /// </summary>
     public string FilePath { get; }
 
-    public string TargetType => "filePath";
-
     /// <summary>
     /// Arguments passed to the Bash script.
     /// </summary>
@@ -138,18 +136,20 @@ public record PowershellFileTask : PowershellTask, IYamlConvertible
             }
         }
 
-        Add("targetType", TargetType, null);
+        var defaultValue = new PowershellFileTask(string.Empty);
+
+        Add("targetType", "filePath", null);
         Add("filePath", FilePath, null);
-        Add("arguments", Arguments, null);
-        Add("workingDirectory", WorkingDirectory, null);
-        Add("errorActionPreference", ErrorActionPreference, ActionPreference.Stop);
-        Add("warningPreference", WarningPreference, ActionPreference.Continue);
-        Add("informationPreference", InformationPreference, ActionPreference.Continue);
-        Add("verbosePreference", VerbosePreference, ActionPreference.Continue);
-        Add("debugPreference", DebugPreference, ActionPreference.Continue);
-        Add("failOnStderr", FailOnStderr, false);
-        Add("ignoreLASTEXITCODE", IgnoreLASTEXITCODE, false);
-        Add("pwsh", Pwsh, false);
+        Add("arguments", Arguments, defaultValue.Arguments);
+        Add("workingDirectory", WorkingDirectory, defaultValue.WorkingDirectory);
+        Add("errorActionPreference", ErrorActionPreference, defaultValue.ErrorActionPreference);
+        Add("warningPreference", WarningPreference, defaultValue.WarningPreference);
+        Add("informationPreference", InformationPreference, defaultValue.InformationPreference);
+        Add("verbosePreference", VerbosePreference, defaultValue.VerbosePreference);
+        Add("debugPreference", DebugPreference, defaultValue.DebugPreference);
+        Add("failOnStderr", FailOnStderr, defaultValue.FailOnStderr);
+        Add("ignoreLASTEXITCODE", IgnoreLASTEXITCODE, defaultValue.IgnoreLASTEXITCODE);
+        Add("pwsh", Pwsh, defaultValue.Pwsh);
 
         nestedObjectSerializer(new AzureDevOpsTask("PowerShell@2", this)
         {

--- a/tests/Sharpliner.Tests/AzureDevOps/Model/Tasks/BashFileTaskTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/Model/Tasks/BashFileTaskTests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using FluentAssertions;
+using Sharpliner.AzureDevOps.Tasks;
+using Xunit;
+
+namespace Sharpliner.Tests.AzureDevOps;
+
+public class BashFileTaskTests : IDisposable
+{
+    public BashFileTaskTests()
+    {
+        SharplinerSerializer.PrettifyYaml = false;
+    }
+
+    public void Dispose()
+    {
+        SharplinerSerializer.PrettifyYaml = true;
+    }
+
+    [Fact]
+    public void Serialize_Bash_File_Task_Test()
+    {
+        var task = new BashFileTask("some/script.sh")
+        {
+            Arguments = "foo bar",
+            ContinueOnError = true,
+            FailOnStderr = true,
+            BashEnv = "~/.bash_profile",
+            DisplayName = "Test task"
+        };
+
+        string yaml = SharplinerSerializer.Serialize(task);
+        yaml.Should().Be(@"task: Bash@3
+displayName: Test task
+inputs:
+  targetType: filePath
+  filePath: some/script.sh
+  arguments: foo bar
+  failOnStderr: true
+  bashEnvValue: ~/.bash_profile
+continueOnError: true
+");
+    }
+
+    [Fact]
+    public void Serialize_Bash_File_Task_With_Defaults_Test()
+    {
+        var task = new BashFileTask("some/script.sh").DisplayAs("Test task");
+
+        string yaml = SharplinerSerializer.Serialize(task);
+        yaml.Should().Be(@"task: Bash@3
+displayName: Test task
+inputs:
+  targetType: filePath
+  filePath: some/script.sh
+");
+    }
+}

--- a/tests/Sharpliner.Tests/AzureDevOps/Model/Tasks/BashFileTaskTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/Model/Tasks/BashFileTaskTests.cs
@@ -1,22 +1,11 @@
-﻿using System;
-using FluentAssertions;
+﻿using FluentAssertions;
 using Sharpliner.AzureDevOps.Tasks;
 using Xunit;
 
 namespace Sharpliner.Tests.AzureDevOps;
 
-public class BashFileTaskTests : IDisposable
+public class BashFileTaskTests
 {
-    public BashFileTaskTests()
-    {
-        SharplinerSerializer.PrettifyYaml = false;
-    }
-
-    public void Dispose()
-    {
-        SharplinerSerializer.PrettifyYaml = true;
-    }
-
     [Fact]
     public void Serialize_Bash_File_Task_Test()
     {
@@ -31,13 +20,16 @@ public class BashFileTaskTests : IDisposable
 
         string yaml = SharplinerSerializer.Serialize(task);
         yaml.Should().Be(@"task: Bash@3
+
 displayName: Test task
+
 inputs:
   targetType: filePath
   filePath: some/script.sh
   arguments: foo bar
   failOnStderr: true
   bashEnvValue: ~/.bash_profile
+
 continueOnError: true
 ");
     }
@@ -49,7 +41,9 @@ continueOnError: true
 
         string yaml = SharplinerSerializer.Serialize(task);
         yaml.Should().Be(@"task: Bash@3
+
 displayName: Test task
+
 inputs:
   targetType: filePath
   filePath: some/script.sh

--- a/tests/Sharpliner.Tests/AzureDevOps/Model/Tasks/PowerShellFileTaskTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/Model/Tasks/PowerShellFileTaskTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using FluentAssertions;
+using Sharpliner.AzureDevOps.Tasks;
+using Xunit;
+
+namespace Sharpliner.Tests.AzureDevOps;
+
+public class PowerShellFileTaskTests : IDisposable
+{
+    public PowerShellFileTaskTests()
+    {
+        SharplinerSerializer.PrettifyYaml = false;
+    }
+
+    public void Dispose()
+    {
+        SharplinerSerializer.PrettifyYaml = true;
+    }
+
+    [Fact]
+    public void Serialize_Powershell_File_Task_Test()
+    {
+        var task = new PowershellFileTask("some\\script.ps1")
+        {
+            Arguments = "foo bar",
+            ContinueOnError = true,
+            ErrorActionPreference = ActionPreference.Inquire,
+            WarningPreference = ActionPreference.Stop,
+            InformationPreference = ActionPreference.Break,
+            DebugPreference = ActionPreference.Suspend,
+            VerbosePreference = ActionPreference.Break,
+            FailOnStderr = true,
+            IgnoreLASTEXITCODE = true,
+            DisplayName = "Test task"
+        };
+
+        string yaml = SharplinerSerializer.Serialize(task);
+        yaml.Should().Be(@"task: PowerShell@2
+displayName: Test task
+inputs:
+  targetType: filePath
+  filePath: some\script.ps1
+  arguments: foo bar
+  errorActionPreference: Inquire
+  warningPreference: Stop
+  informationPreference: Break
+  verbosePreference: Break
+  debugPreference: Suspend
+  failOnStderr: true
+  ignoreLASTEXITCODE: true
+continueOnError: true
+");
+    }
+
+    [Fact]
+    public void Serialize_Powershell_File_Task_With_Defaults_Test()
+    {
+        var task = new PowershellFileTask("some\\script.ps1").DisplayAs("Test task");
+
+        string yaml = SharplinerSerializer.Serialize(task);
+        yaml.Should().Be(@"task: PowerShell@2
+displayName: Test task
+inputs:
+  targetType: filePath
+  filePath: some\script.ps1
+");
+    }
+}

--- a/tests/Sharpliner.Tests/AzureDevOps/Model/Tasks/PowerShellFileTaskTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/Model/Tasks/PowerShellFileTaskTests.cs
@@ -1,22 +1,11 @@
-﻿using System;
-using FluentAssertions;
+﻿using FluentAssertions;
 using Sharpliner.AzureDevOps.Tasks;
 using Xunit;
 
 namespace Sharpliner.Tests.AzureDevOps;
 
-public class PowerShellFileTaskTests : IDisposable
+public class PowerShellFileTaskTests
 {
-    public PowerShellFileTaskTests()
-    {
-        SharplinerSerializer.PrettifyYaml = false;
-    }
-
-    public void Dispose()
-    {
-        SharplinerSerializer.PrettifyYaml = true;
-    }
-
     [Fact]
     public void Serialize_Powershell_File_Task_Test()
     {
@@ -36,7 +25,9 @@ public class PowerShellFileTaskTests : IDisposable
 
         string yaml = SharplinerSerializer.Serialize(task);
         yaml.Should().Be(@"task: PowerShell@2
+
 displayName: Test task
+
 inputs:
   targetType: filePath
   filePath: some\script.ps1
@@ -48,6 +39,7 @@ inputs:
   debugPreference: Suspend
   failOnStderr: true
   ignoreLASTEXITCODE: true
+
 continueOnError: true
 ");
     }
@@ -59,7 +51,9 @@ continueOnError: true
 
         string yaml = SharplinerSerializer.Serialize(task);
         yaml.Should().Be(@"task: PowerShell@2
+
 displayName: Test task
+
 inputs:
   targetType: filePath
   filePath: some\script.ps1

--- a/tests/Sharpliner.Tests/AzureDevOps/Model/Tasks/TaskBuilderTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/Model/Tasks/TaskBuilderTests.cs
@@ -57,7 +57,10 @@ public class TaskBuilderTests
       cat /etc/passwd
       rm -rf tests.xml
 
-  - bash: foo.sh
+  - task: Bash@3
+    inputs:
+      targetType: filePath
+      filePath: foo.sh
 
   - bash: |
       echo ""foo""
@@ -107,8 +110,10 @@ public class TaskBuilderTests
       Connect-AzContext
       Set-AzSubscription --id foo-bar-xyz
 
-  - powershell: foo.ps1
-    targetType: filepath
+  - task: PowerShell@2
+    inputs:
+      targetType: filePath
+      filePath: foo.ps1
 
   - powershell: |+
       Set-ErrorActionPreference Stop
@@ -161,9 +166,11 @@ public class TaskBuilderTests
       Set-AzSubscription --id foo-bar-xyz
     pwsh: true
 
-  - powershell: foo.ps1
-    targetType: filepath
-    pwsh: true
+  - task: PowerShell@2
+    inputs:
+      targetType: filePath
+      filePath: foo.ps1
+      pwsh: true
 
   - powershell: |+
       Set-ErrorActionPreference Stop


### PR DESCRIPTION
Fixes #168 

A little bit unfortunate solution but I found no other better. I wanted to preserve the nice `powershell: inline script` notation so I make an exemption when serializing the tasks that reference a script file so that they serialize as the full task invocations