### PR TITLE
Do not fail the build when no definitions found

### DIFF
--- a/src/Sharpliner/PublishDefinitions.cs
+++ b/src/Sharpliner/PublishDefinitions.cs
@@ -45,7 +45,12 @@ public class PublishDefinitions : Microsoft.Build.Utilities.Task
             PublishDefinition(d.Definition, d.Collection);
         }
 
-        return definitionFound;
+        if (!definitionFound)
+        {
+            Log.LogMessage(MessageImportance.High, $"No definitions found in {Assembly}");
+        }
+
+        return true;
     }
 
     /// <summary>


### PR DESCRIPTION
This will enable cases where we only want to create a definition NuGet that will be used in other Sharpliner projects (#175)