### PR TITLE
Add E2E tests for .nupkg library scenario

### DIFF
--- a/eng/Sharpliner.CI/ProjectBuildSteps.cs
+++ b/eng/Sharpliner.CI/ProjectBuildSteps.cs
@@ -18,7 +18,7 @@ class ProjectBuildSteps : StepLibrary
     {
         StepTemplate(Pipelines.TemplateLocation + "install-dotnet-sdk.yml", new()
         {
-            { "version", "6.0.100" }
+            { "version", "6.0.200" }
         }),
 
         Powershell
@@ -28,6 +28,5 @@ class ProjectBuildSteps : StepLibrary
         DotNet
             .Build(_project, includeNuGetOrg: true)
             .DisplayAs("Build"),
-
     };
 }

--- a/eng/Sharpliner.CI/PublishPipeline.cs
+++ b/eng/Sharpliner.CI/PublishPipeline.cs
@@ -14,7 +14,7 @@ class PublishPipeline : SingleStagePipelineDefinition
         {
             new Job("Publish", "Publish to nuget.org")
             {
-                Pool = new HostedPool("Azure Pipelines", "windows-latest"),
+                Pool = new HostedPool("Azure Pipelines", "windows-2022"),
                 Steps =
                 {
                     Powershell

--- a/eng/Sharpliner.CI/PullRequestPipeline.cs
+++ b/eng/Sharpliner.CI/PullRequestPipeline.cs
@@ -31,6 +31,21 @@ class PullRequestPipeline : SingleStagePipelineDefinition
                     DotNet
                         .Test("tests/**/*.csproj")
                         .DisplayAs("Test"),
+
+                    DotNet.Pack("NuGetWithBasePipeline/NuGetWithBasePipeline.csproj")
+                        .VersionManually("43", "43", "43") with
+                    {
+                        DisplayName = "Pack NuGet.Tests library",
+                        ConfigurationToPack = "Release",         
+                        WorkingDirectory = "tests/NuGet.Tests",
+                    },
+
+                    DotNet.Build("ProjectUsingTheNuGet/ProjectUsingTheNuGet.csproj") with
+                    {
+                        DisplayName = "Build NuGet.Tests project",
+                        IncludeNuGetOrg = false,
+                        WorkingDirectory = "tests/NuGet.Tests",
+                    }
                 }
             }
         },

--- a/eng/Sharpliner.CI/PullRequestPipeline.cs
+++ b/eng/Sharpliner.CI/PullRequestPipeline.cs
@@ -32,8 +32,7 @@ class PullRequestPipeline : SingleStagePipelineDefinition
                         .Test("tests/Sharpliner.Tests/Sharpliner.Tests.csproj")
                         .DisplayAs("Run unit tests"),
 
-                    DotNet.Pack("tests/NuGet.Tests/NuGetWithBasePipeline/NuGetWithBasePipeline.csproj")
-                        .VersionManually("43", "43", "43") with
+                    DotNet.Pack("tests/NuGet.Tests/NuGetWithBasePipeline/NuGetWithBasePipeline.csproj") with
                     {
                         DisplayName = "E2E tests - Pack NuGet.Tests library",
                         ConfigurationToPack = "Release",

--- a/eng/Sharpliner.CI/PullRequestPipeline.cs
+++ b/eng/Sharpliner.CI/PullRequestPipeline.cs
@@ -36,7 +36,7 @@ class PullRequestPipeline : SingleStagePipelineDefinition
                     {
                         DisplayName = "E2E tests - Pack NuGet.Tests library",
                         ConfigurationToPack = "Release",
-                        OutputDir = "../../artifacts/packages",
+                        OutputDir = "artifacts/packages",
                         WorkingDirectory = "tests/NuGet.Tests",
                     },
 

--- a/eng/Sharpliner.CI/PullRequestPipeline.cs
+++ b/eng/Sharpliner.CI/PullRequestPipeline.cs
@@ -36,15 +36,13 @@ class PullRequestPipeline : SingleStagePipelineDefinition
                         .VersionManually("43", "43", "43") with
                     {
                         DisplayName = "E2E tests - Pack NuGet.Tests library",
-                        ConfigurationToPack = "Release",         
-                        WorkingDirectory = "tests/NuGet.Tests",
+                        ConfigurationToPack = "Release",
                     },
 
                     DotNet.Build("tests/NuGet.Tests/ProjectUsingTheNuGet/ProjectUsingTheNuGet.csproj") with
                     {
                         DisplayName = "E2E tests - Build NuGet.Tests project",
                         IncludeNuGetOrg = false,
-                        WorkingDirectory = "tests/NuGet.Tests",
                     }
                 }
             }

--- a/eng/Sharpliner.CI/PullRequestPipeline.cs
+++ b/eng/Sharpliner.CI/PullRequestPipeline.cs
@@ -32,7 +32,8 @@ class PullRequestPipeline : SingleStagePipelineDefinition
                         .Test("tests/Sharpliner.Tests/Sharpliner.Tests.csproj")
                         .DisplayAs("Run unit tests"),
 
-                    DotNet.Pack("tests/NuGet.Tests/NuGetWithBasePipeline/NuGetWithBasePipeline.csproj", "-p:PackageVersion=43.43.43") with
+                    DotNet.Pack("tests/NuGet.Tests/NuGetWithBasePipeline/NuGetWithBasePipeline.csproj")
+                        .VersionManually("43", "43", "43") with
                     {
                         DisplayName = "E2E tests - Pack NuGet.Tests library",
                         ConfigurationToPack = "Release",

--- a/eng/Sharpliner.CI/PullRequestPipeline.cs
+++ b/eng/Sharpliner.CI/PullRequestPipeline.cs
@@ -37,12 +37,15 @@ class PullRequestPipeline : SingleStagePipelineDefinition
                     {
                         DisplayName = "E2E tests - Pack NuGet.Tests library",
                         ConfigurationToPack = "Release",
+                        OutputDir = "../../artifacts/packages",
+                        WorkingDirectory = "tests/NuGet.Tests",
                     },
 
                     DotNet.Build("tests/NuGet.Tests/ProjectUsingTheNuGet/ProjectUsingTheNuGet.csproj") with
                     {
                         DisplayName = "E2E tests - Build NuGet.Tests project",
                         IncludeNuGetOrg = false,
+                        WorkingDirectory = "tests/NuGet.Tests",
                     }
                 }
             }

--- a/eng/Sharpliner.CI/PullRequestPipeline.cs
+++ b/eng/Sharpliner.CI/PullRequestPipeline.cs
@@ -21,7 +21,7 @@ class PullRequestPipeline : SingleStagePipelineDefinition
         {
             new Job("Build", "Build and test")
             {
-                Pool = new HostedPool("Azure Pipelines", "windows-latest"),
+                Pool = new HostedPool("Azure Pipelines", "windows-2022"),
                 Steps =
                 {
                     StepLibrary(new ProjectBuildSteps("src/**/*.csproj")),

--- a/eng/Sharpliner.CI/PullRequestPipeline.cs
+++ b/eng/Sharpliner.CI/PullRequestPipeline.cs
@@ -32,8 +32,7 @@ class PullRequestPipeline : SingleStagePipelineDefinition
                         .Test("tests/Sharpliner.Tests/Sharpliner.Tests.csproj")
                         .DisplayAs("Run unit tests"),
 
-                    DotNet.Pack("tests/NuGet.Tests/NuGetWithBasePipeline/NuGetWithBasePipeline.csproj")
-                        .VersionManually("43", "43", "43") with
+                    DotNet.Pack("tests/NuGet.Tests/NuGetWithBasePipeline/NuGetWithBasePipeline.csproj", "-p:PackageVersion=43.43.43") with
                     {
                         DisplayName = "E2E tests - Pack NuGet.Tests library",
                         ConfigurationToPack = "Release",

--- a/eng/Sharpliner.CI/PullRequestPipeline.cs
+++ b/eng/Sharpliner.CI/PullRequestPipeline.cs
@@ -29,8 +29,8 @@ class PullRequestPipeline : SingleStagePipelineDefinition
                     ValidateYamlsArePublished("eng/Sharpliner.CI/Sharpliner.CI.csproj"),
 
                     DotNet
-                        .Test("tests/**/*.csproj")
-                        .DisplayAs("Test"),
+                        .Test("tests/Sharpliner.Tests/Sharpliner.Tests.csproj")
+                        .DisplayAs("Run unit tests"),
 
                     DotNet.Pack("NuGetWithBasePipeline/NuGetWithBasePipeline.csproj")
                         .VersionManually("43", "43", "43") with

--- a/eng/Sharpliner.CI/PullRequestPipeline.cs
+++ b/eng/Sharpliner.CI/PullRequestPipeline.cs
@@ -32,17 +32,17 @@ class PullRequestPipeline : SingleStagePipelineDefinition
                         .Test("tests/Sharpliner.Tests/Sharpliner.Tests.csproj")
                         .DisplayAs("Run unit tests"),
 
-                    DotNet.Pack("NuGetWithBasePipeline/NuGetWithBasePipeline.csproj")
+                    DotNet.Pack("tests/NuGet.Tests/NuGetWithBasePipeline/NuGetWithBasePipeline.csproj")
                         .VersionManually("43", "43", "43") with
                     {
-                        DisplayName = "Pack NuGet.Tests library",
+                        DisplayName = "E2E tests - Pack NuGet.Tests library",
                         ConfigurationToPack = "Release",         
                         WorkingDirectory = "tests/NuGet.Tests",
                     },
 
-                    DotNet.Build("ProjectUsingTheNuGet/ProjectUsingTheNuGet.csproj") with
+                    DotNet.Build("tests/NuGet.Tests/ProjectUsingTheNuGet/ProjectUsingTheNuGet.csproj") with
                     {
-                        DisplayName = "Build NuGet.Tests project",
+                        DisplayName = "E2E tests - Build NuGet.Tests project",
                         IncludeNuGetOrg = false,
                         WorkingDirectory = "tests/NuGet.Tests",
                     }

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -56,10 +56,6 @@ jobs:
     inputs:
       command: pack
       packagesToPack: tests/NuGet.Tests/NuGetWithBasePipeline/NuGetWithBasePipeline.csproj
-      versioningScheme: byPrereleaseNumber
-      majorVersion: 43
-      minorVersion: 43
-      patchVersion: 43
       configurationToPack: Release
       outputDir: ../../artifacts/packages
       workingDirectory: tests/NuGet.Tests

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -61,7 +61,6 @@ jobs:
       minorVersion: 43
       patchVersion: 43
       configurationToPack: Release
-      workingDirectory: tests/NuGet.Tests
 
   - task: DotNetCoreCLI@2
     displayName: E2E tests - Build NuGet.Tests project
@@ -69,4 +68,3 @@ jobs:
       command: build
       projects: tests/NuGet.Tests/ProjectUsingTheNuGet/ProjectUsingTheNuGet.csproj
       includeNuGetOrg: false
-      workingDirectory: tests/NuGet.Tests

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -25,7 +25,7 @@ jobs:
   steps:
   - template: templates/install-dotnet-sdk.yml
     parameters:
-      version: 6.0.100
+      version: 6.0.200
 
   - powershell: |-
       New-Item -Path 'artifacts' -Name 'packages' -ItemType 'directory'

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -46,10 +46,10 @@ jobs:
       arguments: -p:FailIfChanged=true
 
   - task: DotNetCoreCLI@2
-    displayName: Test
+    displayName: Run unit tests
     inputs:
       command: test
-      projects: tests/**/*.csproj
+      projects: tests/Sharpliner.Tests/Sharpliner.Tests.csproj
 
   - task: DotNetCoreCLI@2
     displayName: Pack NuGet.Tests library

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -21,7 +21,7 @@ jobs:
   displayName: Build and test
   pool:
     name: Azure Pipelines
-    vmImage: windows-latest
+    vmImage: windows-2022
   steps:
   - template: templates/install-dotnet-sdk.yml
     parameters:

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -61,6 +61,8 @@ jobs:
       minorVersion: 43
       patchVersion: 43
       configurationToPack: Release
+      outputDir: ../../artifacts/packages
+      workingDirectory: tests/NuGet.Tests
 
   - task: DotNetCoreCLI@2
     displayName: E2E tests - Build NuGet.Tests project
@@ -68,3 +70,4 @@ jobs:
       command: build
       projects: tests/NuGet.Tests/ProjectUsingTheNuGet/ProjectUsingTheNuGet.csproj
       includeNuGetOrg: false
+      workingDirectory: tests/NuGet.Tests

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -56,7 +56,10 @@ jobs:
     inputs:
       command: pack
       packagesToPack: tests/NuGet.Tests/NuGetWithBasePipeline/NuGetWithBasePipeline.csproj
-      arguments: -p:PackageVersion=43.43.43
+      versioningScheme: byPrereleaseNumber
+      majorVersion: 43
+      minorVersion: 43
+      patchVersion: 43
       configurationToPack: Release
       outputDir: ../../artifacts/packages
       workingDirectory: tests/NuGet.Tests

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -56,10 +56,7 @@ jobs:
     inputs:
       command: pack
       packagesToPack: tests/NuGet.Tests/NuGetWithBasePipeline/NuGetWithBasePipeline.csproj
-      versioningScheme: byPrereleaseNumber
-      majorVersion: 43
-      minorVersion: 43
-      patchVersion: 43
+      arguments: -p:PackageVersion=43.43.43
       configurationToPack: Release
       outputDir: ../../artifacts/packages
       workingDirectory: tests/NuGet.Tests

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -52,10 +52,10 @@ jobs:
       projects: tests/Sharpliner.Tests/Sharpliner.Tests.csproj
 
   - task: DotNetCoreCLI@2
-    displayName: Pack NuGet.Tests library
+    displayName: E2E tests - Pack NuGet.Tests library
     inputs:
       command: pack
-      packagesToPack: NuGetWithBasePipeline/NuGetWithBasePipeline.csproj
+      packagesToPack: tests/NuGet.Tests/NuGetWithBasePipeline/NuGetWithBasePipeline.csproj
       versioningScheme: byPrereleaseNumber
       majorVersion: 43
       minorVersion: 43
@@ -64,9 +64,9 @@ jobs:
       workingDirectory: tests/NuGet.Tests
 
   - task: DotNetCoreCLI@2
-    displayName: Build NuGet.Tests project
+    displayName: E2E tests - Build NuGet.Tests project
     inputs:
       command: build
-      projects: ProjectUsingTheNuGet/ProjectUsingTheNuGet.csproj
+      projects: tests/NuGet.Tests/ProjectUsingTheNuGet/ProjectUsingTheNuGet.csproj
       includeNuGetOrg: false
       workingDirectory: tests/NuGet.Tests

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -50,3 +50,23 @@ jobs:
     inputs:
       command: test
       projects: tests/**/*.csproj
+
+  - task: DotNetCoreCLI@2
+    displayName: Pack NuGet.Tests library
+    inputs:
+      command: pack
+      packagesToPack: NuGetWithBasePipeline/NuGetWithBasePipeline.csproj
+      versioningScheme: byPrereleaseNumber
+      majorVersion: 43
+      minorVersion: 43
+      patchVersion: 43
+      configurationToPack: Release
+      workingDirectory: tests/NuGet.Tests
+
+  - task: DotNetCoreCLI@2
+    displayName: Build NuGet.Tests project
+    inputs:
+      command: build
+      projects: ProjectUsingTheNuGet/ProjectUsingTheNuGet.csproj
+      includeNuGetOrg: false
+      workingDirectory: tests/NuGet.Tests

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -57,7 +57,7 @@ jobs:
       command: pack
       packagesToPack: tests/NuGet.Tests/NuGetWithBasePipeline/NuGetWithBasePipeline.csproj
       configurationToPack: Release
-      outputDir: ../../artifacts/packages
+      outputDir: artifacts/packages
       workingDirectory: tests/NuGet.Tests
 
   - task: DotNetCoreCLI@2

--- a/eng/pipelines/publish.yml
+++ b/eng/pipelines/publish.yml
@@ -25,7 +25,7 @@ jobs:
 
   - template: templates/install-dotnet-sdk.yml
     parameters:
-      version: 6.0.100
+      version: 6.0.200
 
   - powershell: |-
       New-Item -Path 'artifacts' -Name 'packages' -ItemType 'directory'

--- a/eng/pipelines/publish.yml
+++ b/eng/pipelines/publish.yml
@@ -10,7 +10,7 @@ jobs:
   displayName: Publish to nuget.org
   pool:
     name: Azure Pipelines
-    vmImage: windows-latest
+    vmImage: windows-2022
   steps:
   - powershell: |+
       $tag = git tag --points-at HEAD

--- a/tests/NuGet.Tests/NuGet.config
+++ b/tests/NuGet.Tests/NuGet.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="sharpliner-local" value="../../../artifacts/packages" />
+    <add key="sharpliner-local" value="../../artifacts/packages" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/tests/NuGet.Tests/NuGet.config
+++ b/tests/NuGet.Tests/NuGet.config
@@ -2,9 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="sharpliner-local-1" value="../../artifacts/packages" />
-    <add key="sharpliner-local-2" value="artifacts/packages" />
-    <add key="sharpliner-local-3" value="../../../artifacts/packages" />
+    <add key="sharpliner-local" value="../../artifacts/packages" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/tests/NuGet.Tests/NuGet.config
+++ b/tests/NuGet.Tests/NuGet.config
@@ -2,7 +2,9 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="sharpliner-local" value="../../artifacts/packages" />
+    <add key="sharpliner-local-1" value="../../artifacts/packages" />
+    <add key="sharpliner-local-2" value="artifacts/packages" />
+    <add key="sharpliner-local-3" value="../../../artifacts/packages" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/tests/NuGet.Tests/NuGet.config
+++ b/tests/NuGet.Tests/NuGet.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="sharpliner-local" value="../../artifacts/packages" />
+    <add key="sharpliner-local" value="../../../artifacts/packages" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/tests/NuGet.Tests/NuGet.config
+++ b/tests/NuGet.Tests/NuGet.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="sharpliner-local" value="../../artifacts/packages" />
+  </packageSources>
+  <disabledPackageSources />
+</configuration>

--- a/tests/NuGet.Tests/NuGetWithBasePipeline/BasePipelineFromNuGet.cs
+++ b/tests/NuGet.Tests/NuGetWithBasePipeline/BasePipelineFromNuGet.cs
@@ -1,0 +1,30 @@
+using Sharpliner.AzureDevOps;
+using Sharpliner.AzureDevOps.Tasks;
+
+namespace Tests.NuGetWithBasePipeline;
+
+// These NuGet.Tests are E2E testing following scenario:
+// 1. We create a "library" project with an arbitrary Sharpliner definition
+// 2. We publish a .nupkg of this library project
+// 3. We reference this .nupkg in another project
+
+// This is testing that all the referenced DLLs are loaded well even for this transitive scenario.
+// This is testing user scenarios where people want to publish definitions in the form of NuGet and re-use it in other projects.
+
+// This class is the one that goes into the NuGet
+public abstract class BasePipelineFromNuGet : SingleStagePipelineDefinition
+{
+    public override SingleStagePipeline Pipeline => new()
+    {
+        Jobs =
+        {
+            new Job("Test job")
+            {
+                Steps =
+                {
+                    Script.Inline("echo 'Hello World!'")
+                }
+            }
+        }
+    };
+}

--- a/tests/NuGet.Tests/NuGetWithBasePipeline/BasePipelineFromNuGet.cs
+++ b/tests/NuGet.Tests/NuGetWithBasePipeline/BasePipelineFromNuGet.cs
@@ -18,7 +18,7 @@ public abstract class BasePipelineFromNuGet : SingleStagePipelineDefinition
     {
         Jobs =
         {
-            new Job("Test job")
+            new Job("TestJob")
             {
                 Steps =
                 {

--- a/tests/NuGet.Tests/NuGetWithBasePipeline/NuGetWithBasePipeline.csproj
+++ b/tests/NuGet.Tests/NuGetWithBasePipeline/NuGetWithBasePipeline.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Sharpliner" Version="43.43.43" />
+  </ItemGroup>
+
+</Project>

--- a/tests/NuGet.Tests/ProjectUsingTheNuGet/NuGetTestDefinition.cs
+++ b/tests/NuGet.Tests/ProjectUsingTheNuGet/NuGetTestDefinition.cs
@@ -1,0 +1,20 @@
+using Sharpliner.AzureDevOps;
+using Sharpliner.AzureDevOps.Tasks;
+
+namespace NuGetWithBasePipeline;
+
+// These NuGet.Tests are E2E testing following scenario:
+// 1. We create a "library" project with an arbitrary Sharpliner definition
+// 2. We publish a .nupkg of this library project
+// 3. We reference this .nupkg in another project
+
+// This is testing that all the referenced DLLs are loaded well even for this transitive scenario.
+// This is testing user scenarios where people want to publish definitions in the form of NuGet and re-use it in other projects.
+
+// This class is the one that uses the library NuGet
+public  class NuGetTestDefinition : BasePipelineFromNuGet
+{
+    public override string TargetFile => Path.Combine("tests", "NuGet.Tests", "NuGetTestDefinition.yml");
+
+    public override TargetPathType TargetPathType => TargetPathType.RelativeToGitRoot;
+}

--- a/tests/NuGet.Tests/ProjectUsingTheNuGet/NuGetTestDefinition.cs
+++ b/tests/NuGet.Tests/ProjectUsingTheNuGet/NuGetTestDefinition.cs
@@ -1,7 +1,7 @@
 using Sharpliner.AzureDevOps;
 using Sharpliner.AzureDevOps.Tasks;
 
-namespace NuGetWithBasePipeline;
+namespace Tests.NuGetWithBasePipeline;
 
 // These NuGet.Tests are E2E testing following scenario:
 // 1. We create a "library" project with an arbitrary Sharpliner definition

--- a/tests/NuGet.Tests/ProjectUsingTheNuGet/NuGetTestDefinition.cs
+++ b/tests/NuGet.Tests/ProjectUsingTheNuGet/NuGetTestDefinition.cs
@@ -1,3 +1,5 @@
+using System.IO;
+using Sharpliner;
 using Sharpliner.AzureDevOps;
 using Sharpliner.AzureDevOps.Tasks;
 

--- a/tests/NuGet.Tests/ProjectUsingTheNuGet/ProjectUsingTheNuGet.csproj
+++ b/tests/NuGet.Tests/ProjectUsingTheNuGet/ProjectUsingTheNuGet.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Sharpliner" Version="43.43.43" />
-    <PackageReference Include="NuGetWithBasePipeline" Version="43.43.43*" />
+    <PackageReference Include="NuGetWithBasePipeline" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/NuGet.Tests/ProjectUsingTheNuGet/ProjectUsingTheNuGet.csproj
+++ b/tests/NuGet.Tests/ProjectUsingTheNuGet/ProjectUsingTheNuGet.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Sharpliner" Version="43.43.43" />
+    <PackageReference Include="NuGetWithBasePipeline" Version="43.43.43" />
+  </ItemGroup>
+
+</Project>

--- a/tests/NuGet.Tests/ProjectUsingTheNuGet/ProjectUsingTheNuGet.csproj
+++ b/tests/NuGet.Tests/ProjectUsingTheNuGet/ProjectUsingTheNuGet.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Sharpliner" Version="43.43.43" />
-    <PackageReference Include="NuGetWithBasePipeline" Version="43.43.43" />
+    <PackageReference Include="NuGetWithBasePipeline" Version="43.43.43*" />
   </ItemGroup>
 
 </Project>

--- a/tests/NuGet.Tests/README.md
+++ b/tests/NuGet.Tests/README.md
@@ -1,0 +1,7 @@
+These NuGet.Tests are E2E testing following scenario:
+1. We create a "library" project with some Sharpliner definition
+2. We publish a .nupkg of this library project
+3. We reference this .nupkg in another project
+
+This is testing that all the referenced DLLs are loaded well even for this transitive scenario.
+This is testing user scenarios where people want to publish definitions in the form of NuGet and re-use it in other projects.


### PR DESCRIPTION
These NuGet.Tests are E2E testing following scenario:
1. We create a "library" project with some Sharpliner definition
2. We publish a .nupkg of this library project
3. We reference this .nupkg in another project

This is testing that all the referenced DLLs are loaded well even for this transitive scenario.
This is testing user scenarios where people want to publish definitions in the form of NuGet and re-use it in other projects.

Related to #175