### PR TITLE
Move logic out of `ISharplinerDefinition`

### DIFF
--- a/src/Sharpliner/AzureDevOps/PipelineDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/PipelineDefinition.cs
@@ -24,7 +24,7 @@ public abstract class PipelineDefinitionBase<TPipeline>
     /// 
     /// Leave empty array to omit file header.
     /// </summary>
-    public virtual string[]? Header => ISharplinerDefinition.GetDefaultHeader(GetType());
+    public virtual string[]? Header => SharplinerPublisher.GetDefaultHeader(GetType());
 
     /// <summary>
     /// Define the pipeline by implementing this field.

--- a/src/Sharpliner/AzureDevOps/PipelineDefinitionCollection.cs
+++ b/src/Sharpliner/AzureDevOps/PipelineDefinitionCollection.cs
@@ -42,7 +42,7 @@ internal class PipelineDefinitionWrapper<T> : ISharplinerDefinition where T : Pi
         TargetFile = data.TargetFile;
         Pipeline = data.Pipeline;
         TargetPathType = data.PathType;
-        Header = data.Header ?? ISharplinerDefinition.GetDefaultHeader(definitionType);
+        Header = data.Header ?? SharplinerPublisher.GetDefaultHeader(definitionType);
     }
 
     public string TargetFile { get; }

--- a/src/Sharpliner/AzureDevOps/TemplateDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/TemplateDefinition.cs
@@ -179,7 +179,7 @@ public abstract class TemplateDefinition<T> : TemplateDefinition, ISharplinerDef
     /// 
     /// Leave empty array to omit file header.
     /// </summary>
-    public virtual string[]? Header => ISharplinerDefinition.GetDefaultHeader(GetType());
+    public virtual string[]? Header => SharplinerPublisher.GetDefaultHeader(GetType());
 
     /// <summary>
     /// Disallow any other types than what we define here as AzDO only supports these.

--- a/src/Sharpliner/AzureDevOps/TemplateDefinitionCollection.cs
+++ b/src/Sharpliner/AzureDevOps/TemplateDefinitionCollection.cs
@@ -53,7 +53,7 @@ internal class TemplateDefinitionWrapper<T> : TemplateDefinition<T>
         Definition = data.Definition;
         TargetPathType = data.PathType;
         Parameters = data.Parameters ?? new List<TemplateParameter>();
-        _header = data.Header ?? ISharplinerDefinition.GetDefaultHeader(definitionType);
+        _header = data.Header ?? SharplinerPublisher.GetDefaultHeader(definitionType);
         YamlProperty = yamlMemberName;
         Validations = validations;
     }

--- a/src/Sharpliner/ISharplinerDefinition.cs
+++ b/src/Sharpliner/ISharplinerDefinition.cs
@@ -1,7 +1,4 @@
-﻿using System.IO;
-using System.Reflection;
-using System;
-using Sharpliner.Common;
+﻿using Sharpliner.Common;
 using System.Collections.Generic;
 
 namespace Sharpliner;
@@ -12,19 +9,6 @@ namespace Sharpliner;
 /// </summary>
 public interface ISharplinerDefinition
 {
-    /// <summary>
-    /// Default YAML file header
-    /// </summary>
-    public static string[] GetDefaultHeader(Type type) => new[]
-    {
-        string.Empty,
-        "DO NOT MODIFY THIS FILE!",
-        string.Empty,
-        $"This YAML was auto-generated from { type.Name }",
-        $"To make changes, change the C# definition and rebuild its project",
-        string.Empty,
-    };
-
     /// <summary>
     /// Path to the YAML file/folder where this definition/collection will be exported to
     /// Example: "/pipelines/ci.yaml"
@@ -42,70 +26,6 @@ public interface ISharplinerDefinition
     /// Leave empty array to omit file header
     /// </summary>
     string[]? Header { get; }
-
-    /// <summary>
-    /// Gets the path where YAML of this definition should be published to
-    /// </summary>
-    string GetTargetPath()
-    {
-        switch (TargetPathType)
-        {
-            case TargetPathType.RelativeToGitRoot:
-                var currentDir = new DirectoryInfo(Directory.GetCurrentDirectory());
-                while (!Directory.Exists(Path.Combine(currentDir.FullName, ".git")))
-                {
-                    currentDir = currentDir.Parent;
-
-                    if (currentDir == null)
-                    {
-                        throw new Exception($"Failed to find git repository in {Directory.GetParent(Assembly.GetExecutingAssembly().Location)?.FullName}");
-                    }
-                }
-
-                return Path.Combine(currentDir.FullName, TargetFile);
-
-            case TargetPathType.RelativeToCurrentDir:
-                return TargetFile;
-
-            case TargetPathType.RelativeToAssembly:
-                return Path.Combine(Assembly.GetExecutingAssembly().Location, TargetFile);
-
-            case TargetPathType.Absolute:
-                return TargetFile;
-
-            default:
-                throw new ArgumentOutOfRangeException(nameof(TargetPathType));
-        }
-    }
-
-    /// <summary>
-    /// Publishes the definition into a YAML file
-    /// </summary>
-    void Publish()
-    {
-        string fileName = GetTargetPath();
-        var fileContents = Serialize();
-
-        if (SharplinerConfiguration.Current.Serialization.IncludeHeaders)
-        {
-            var header = Header ?? GetDefaultHeader(GetType());
-
-            if (header.Length > 0)
-            {
-                const string hash = "### ";
-                fileContents = hash + string.Join(Environment.NewLine + hash, header) + Environment.NewLine + Environment.NewLine + fileContents;
-                fileContents = fileContents.Replace(" \r\n", "\r\n").Replace(" \n", "\n"); // Remove trailing spaces from the default template
-            }
-        }
-
-        var targetDirectory = Path.GetDirectoryName(fileName)!;
-        if (!string.IsNullOrEmpty(targetDirectory) && !Directory.Exists(targetDirectory))
-        {
-            Directory.CreateDirectory(targetDirectory);
-        }
-
-        File.WriteAllText(fileName, fileContents);
-    }
 
     /// <summary>
     /// Returns the list of validations that should be run on the definition (e.g. wrong dependsOn, artifact name typos..).


### PR DESCRIPTION
Previously, the logic was in the interface because we had issues with binding context (#179). Now we can afford to keep it more as data model only