### PR TITLE
Rename `TemplateParameter` to `Parameter`

### DIFF
--- a/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
@@ -342,8 +342,8 @@ public abstract class AzureDevOpsDefinition
     /// <param name="displayName">Display name of the parameter shown in the UI when creating pipeline run</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
     /// <param name="allowedValues">Allowed list of values (for some data types)</param>
-    protected static TemplateParameter StringParameter(string name, string displayName, string? defaultValue = null, IEnumerable<string>? allowedValues = null)
-        => new StringTemplateParameter(name, displayName, defaultValue, allowedValues);
+    protected static Parameter StringParameter(string name, string? displayName = null, string? defaultValue = null, IEnumerable<string>? allowedValues = null)
+        => new StringParameter(name, displayName, defaultValue, allowedValues);
 
     /// <summary>
     /// Defines a number template parameter
@@ -352,8 +352,8 @@ public abstract class AzureDevOpsDefinition
     /// <param name="displayName">Display name of the parameter shown in the UI when creating pipeline run</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
     /// <param name="allowedValues">Allowed list of values (for some data types)</param>
-    protected static TemplateParameter NumberParameter(string name, string displayName, int defaultValue = 0, IEnumerable<int>? allowedValues = null)
-        => new NumberTemplateParameter(name, displayName, defaultValue, allowedValues);
+    protected static Parameter NumberParameter(string name, string? displayName = null, int defaultValue = 0, IEnumerable<int>? allowedValues = null)
+        => new NumberParameter(name, displayName, defaultValue, allowedValues);
 
     /// <summary>
     /// Defines a boolean template parameter
@@ -361,8 +361,8 @@ public abstract class AzureDevOpsDefinition
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="displayName">Display name of the parameter shown in the UI when creating pipeline run</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    protected static TemplateParameter BooleanParameter(string name, string displayName, bool defaultValue = false)
-        => new BooleanTemplateParameter(name, displayName, defaultValue);
+    protected static Parameter BooleanParameter(string name, string? displayName = null, bool defaultValue = false)
+        => new BooleanParameter(name, displayName, defaultValue);
 
     /// <summary>
     /// Defines a object template parameter
@@ -370,8 +370,8 @@ public abstract class AzureDevOpsDefinition
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="displayName">Display name of the parameter shown in the UI when creating pipeline run</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    protected static TemplateParameter ObjectParameter(string name, string displayName, ConditionedDictionary? defaultValue = null)
-        => new ObjectTemplateParameter(name, displayName, defaultValue);
+    protected static Parameter ObjectParameter(string name, string? displayName = null, ConditionedDictionary? defaultValue = null)
+        => new ObjectParameter(name, displayName, defaultValue);
 
     /// <summary>
     /// Defines a step template parameter
@@ -379,8 +379,8 @@ public abstract class AzureDevOpsDefinition
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="displayName">Display name of the parameter shown in the UI when creating pipeline run</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    protected static TemplateParameter StepParameter(string name, string displayName, Step? defaultValue = null)
-        => new StepTemplateParameter(name, displayName, defaultValue);
+    protected static Parameter StepParameter(string name, string? displayName = null, Step? defaultValue = null)
+        => new StepParameter(name, displayName, defaultValue);
 
     /// <summary>
     /// Defines a stepList template parameter
@@ -388,8 +388,8 @@ public abstract class AzureDevOpsDefinition
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="displayName">Display name of the parameter shown in the UI when creating pipeline run</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    protected static TemplateParameter StepListParameter(string name, string displayName, ConditionedList<Step>? defaultValue = null)
-        => new StepListTemplateParameter(name, displayName, defaultValue);
+    protected static Parameter StepListParameter(string name, string? displayName = null, ConditionedList<Step>? defaultValue = null)
+        => new StepListParameter(name, displayName, defaultValue);
 
     /// <summary>
     /// Defines a job template parameter
@@ -397,8 +397,8 @@ public abstract class AzureDevOpsDefinition
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="displayName">Display name of the parameter shown in the UI when creating pipeline run</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    protected static TemplateParameter JobParameter(string name, string displayName, JobBase? defaultValue = null)
-        => new JobTemplateParameter(name, displayName, defaultValue);
+    protected static Parameter JobParameter(string name, string? displayName = null, JobBase? defaultValue = null)
+        => new JobParameter(name, displayName, defaultValue);
 
     /// <summary>
     /// Defines a jobList template parameter
@@ -406,8 +406,8 @@ public abstract class AzureDevOpsDefinition
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="displayName">Display name of the parameter shown in the UI when creating pipeline run</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    protected static TemplateParameter JobListParameter(string name, string displayName, ConditionedList<JobBase>? defaultValue = null)
-        => new JobListTemplateParameter(name, displayName, defaultValue);
+    protected static Parameter JobListParameter(string name, string? displayName = null, ConditionedList<JobBase>? defaultValue = null)
+        => new JobListParameter(name, displayName, defaultValue);
 
     /// <summary>
     /// Defines a deployment job template parameter
@@ -415,8 +415,8 @@ public abstract class AzureDevOpsDefinition
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="displayName">Display name of the parameter shown in the UI when creating pipeline run</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    protected static TemplateParameter DeploymentParameter(string name, string displayName, DeploymentJob? defaultValue = null)
-        => new DeploymentTemplateParameter(name, displayName, defaultValue);
+    protected static Parameter DeploymentParameter(string name, string? displayName = null, DeploymentJob? defaultValue = null)
+        => new DeploymentParameter(name, displayName, defaultValue);
 
     /// <summary>
     /// Defines a deploymentList template parameter
@@ -424,8 +424,8 @@ public abstract class AzureDevOpsDefinition
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="displayName">Display name of the parameter shown in the UI when creating pipeline run</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    protected static TemplateParameter DeploymentListParameter(string name, string displayName, ConditionedList<DeploymentJob>? defaultValue = null)
-        => new DeploymentListTemplateParameter(name, displayName, defaultValue);
+    protected static Parameter DeploymentListParameter(string name, string? displayName = null, ConditionedList<DeploymentJob>? defaultValue = null)
+        => new DeploymentListParameter(name, displayName, defaultValue);
 
     /// <summary>
     /// Defines a stage template parameter
@@ -433,8 +433,8 @@ public abstract class AzureDevOpsDefinition
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="displayName">Display name of the parameter shown in the UI when creating pipeline run</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    protected static TemplateParameter StageParameter(string name, string displayName, Stage? defaultValue = null)
-        => new StageTemplateParameter(name, displayName, defaultValue);
+    protected static Parameter StageParameter(string name, string? displayName = null, Stage? defaultValue = null)
+        => new StageParameter(name, displayName, defaultValue);
 
     /// <summary>
     /// Defines a stageList template parameter
@@ -442,8 +442,8 @@ public abstract class AzureDevOpsDefinition
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="displayName">Display name of the parameter shown in the UI when creating pipeline run</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    protected static TemplateParameter StageListParameter(string name, string displayName, ConditionedList<Stage>? defaultValue = null)
-        => new StageListTemplateParameter(name, displayName, defaultValue);
+    protected static Parameter StageListParameter(string name, string? displayName = null, ConditionedList<Stage>? defaultValue = null)
+        => new StageListParameter(name, displayName, defaultValue);
 
     #endregion
 

--- a/src/Sharpliner/AzureDevOps/Parameter.cs
+++ b/src/Sharpliner/AzureDevOps/Parameter.cs
@@ -7,7 +7,7 @@ using YamlDotNet.Serialization;
 
 namespace Sharpliner.AzureDevOps;
 
-public abstract record TemplateParameter
+public abstract record Parameter
 {
     /// <summary>
     /// Name of the parameter, can be referenced in the template as ${{ parameters.name }}
@@ -24,7 +24,7 @@ public abstract record TemplateParameter
     [YamlMember(Order = 110)]
     public abstract string Type { get; }
 
-    internal TemplateParameter(string name, string? displayName)
+    internal Parameter(string name, string? displayName = null)
     {
         Name = name;
         DisplayName = displayName;
@@ -34,7 +34,7 @@ public abstract record TemplateParameter
 /// <summary>
 /// Allows to define which parameters the template expects.
 /// </summary>
-public abstract record TemplateParameter<T> : TemplateParameter
+public abstract record Parameter<T> : Parameter
 {
     /// <summary>
     /// Default value; if no default, then the parameter MUST be given by the user at runtime
@@ -48,7 +48,7 @@ public abstract record TemplateParameter<T> : TemplateParameter
     [YamlMember(Alias = "values", Order = 130)]
     public IEnumerable<T>? AllowedValues { get; init; }
 
-    internal TemplateParameter(string name, string? displayName, T? defaultValue = default, IEnumerable<T>? allowedValues = null)
+    internal Parameter(string name, string? displayName = null, T? defaultValue = default, IEnumerable<T>? allowedValues = null)
         : base(name, displayName)
     {
         Default = defaultValue;
@@ -56,7 +56,7 @@ public abstract record TemplateParameter<T> : TemplateParameter
     }
 }
 
-public sealed record StringTemplateParameter : TemplateParameter<string>
+public sealed record StringParameter : Parameter<string>
 {
     /// <summary>
     /// Define a template parameter
@@ -65,7 +65,7 @@ public sealed record StringTemplateParameter : TemplateParameter<string>
     /// <param name="displayName">Display name of the parameter in case this is a pipeline parameter</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
     /// <param name="allowedValues">Allowed list of values (for some data types)</param>
-    internal StringTemplateParameter(string name, string? displayName, string? defaultValue = null, IEnumerable<string>? allowedValues = null)
+    internal StringParameter(string name, string? displayName = null, string? defaultValue = null, IEnumerable<string>? allowedValues = null)
         : base(name, displayName, defaultValue, allowedValues)
     {
     }
@@ -73,7 +73,7 @@ public sealed record StringTemplateParameter : TemplateParameter<string>
     public override string Type => "string";
 }
 
-public sealed record NumberTemplateParameter : TemplateParameter<int>
+public sealed record NumberParameter : Parameter<int>
 {
     /// <summary>
     /// Define a template parameter
@@ -82,7 +82,7 @@ public sealed record NumberTemplateParameter : TemplateParameter<int>
     /// <param name="displayName">Display name of the parameter in case this is a pipeline parameter</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
     /// <param name="allowedValues">Allowed list of values (for some data types)</param>
-    internal NumberTemplateParameter(string name, string? displayName, int defaultValue = 0, IEnumerable<int>? allowedValues = null)
+    internal NumberParameter(string name, string? displayName = null, int defaultValue = 0, IEnumerable<int>? allowedValues = null)
         : base(name, displayName, defaultValue, allowedValues)
     {
     }
@@ -90,7 +90,7 @@ public sealed record NumberTemplateParameter : TemplateParameter<int>
     public override string Type => "number";
 }
 
-public sealed record BooleanTemplateParameter : TemplateParameter<bool>
+public sealed record BooleanParameter : Parameter<bool>
 {
     /// <summary>
     /// Define a template parameter
@@ -98,7 +98,7 @@ public sealed record BooleanTemplateParameter : TemplateParameter<bool>
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="displayName">Display name of the parameter in case this is a pipeline parameter</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    internal BooleanTemplateParameter(string name, string? displayName, bool defaultValue = false)
+    internal BooleanParameter(string name, string? displayName = null, bool defaultValue = false)
         : base(name, displayName, defaultValue)
     {
     }
@@ -106,7 +106,7 @@ public sealed record BooleanTemplateParameter : TemplateParameter<bool>
     public override string Type => "boolean";
 }
 
-public sealed record ObjectTemplateParameter : TemplateParameter<ConditionedDictionary>
+public sealed record ObjectParameter : Parameter<ConditionedDictionary>
 {
     /// <summary>
     /// Define a template parameter
@@ -114,7 +114,7 @@ public sealed record ObjectTemplateParameter : TemplateParameter<ConditionedDict
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="displayName">Display name of the parameter in case this is a pipeline parameter</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    internal ObjectTemplateParameter(string name, string? displayName, ConditionedDictionary? defaultValue = null)
+    internal ObjectParameter(string name, string? displayName = null, ConditionedDictionary? defaultValue = null)
         : base(name, displayName, defaultValue, null)
     {
     }
@@ -122,7 +122,7 @@ public sealed record ObjectTemplateParameter : TemplateParameter<ConditionedDict
     public override string Type => "object";
 }
 
-public sealed record StepTemplateParameter : TemplateParameter<Step>
+public sealed record StepParameter : Parameter<Step>
 {
     /// <summary>
     /// Define a template parameter
@@ -130,7 +130,7 @@ public sealed record StepTemplateParameter : TemplateParameter<Step>
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="displayName">Display name of the parameter in case this is a pipeline parameter</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    internal StepTemplateParameter(string name, string? displayName, Step? defaultValue = null)
+    internal StepParameter(string name, string? displayName = null, Step? defaultValue = null)
         : base(name, displayName, defaultValue, null)
     {
     }
@@ -138,7 +138,7 @@ public sealed record StepTemplateParameter : TemplateParameter<Step>
     public override string Type => "step";
 }
 
-public sealed record StepListTemplateParameter : TemplateParameter<ConditionedList<Step>>
+public sealed record StepListParameter : Parameter<ConditionedList<Step>>
 {
     /// <summary>
     /// Define a template parameter
@@ -146,7 +146,7 @@ public sealed record StepListTemplateParameter : TemplateParameter<ConditionedLi
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="displayName">Display name of the parameter in case this is a pipeline parameter</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    internal StepListTemplateParameter(string name, string? displayName, ConditionedList<Step>? defaultValue = null)
+    internal StepListParameter(string name, string? displayName = null, ConditionedList<Step>? defaultValue = null)
         : base(name, displayName, defaultValue, null)
     {
     }
@@ -154,7 +154,7 @@ public sealed record StepListTemplateParameter : TemplateParameter<ConditionedLi
     public override string Type => "stepList";
 }
 
-public sealed record JobTemplateParameter : TemplateParameter<JobBase>
+public sealed record JobParameter : Parameter<JobBase>
 {
     /// <summary>
     /// Define a template parameter
@@ -162,7 +162,7 @@ public sealed record JobTemplateParameter : TemplateParameter<JobBase>
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="displayName">Display name of the parameter in case this is a pipeline parameter</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    internal JobTemplateParameter(string name, string? displayName, JobBase? defaultValue = null)
+    internal JobParameter(string name, string? displayName = null, JobBase? defaultValue = null)
         : base(name, displayName, defaultValue, null)
     {
     }
@@ -170,7 +170,7 @@ public sealed record JobTemplateParameter : TemplateParameter<JobBase>
     public override string Type => "job";
 }
 
-public sealed record JobListTemplateParameter : TemplateParameter<ConditionedList<JobBase>>
+public sealed record JobListParameter : Parameter<ConditionedList<JobBase>>
 {
     /// <summary>
     /// Define a template parameter
@@ -178,7 +178,7 @@ public sealed record JobListTemplateParameter : TemplateParameter<ConditionedLis
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="displayName">Display name of the parameter in case this is a pipeline parameter</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    internal JobListTemplateParameter(string name, string? displayName, ConditionedList<JobBase>? defaultValue = null)
+    internal JobListParameter(string name, string? displayName = null, ConditionedList<JobBase>? defaultValue = null)
         : base(name, displayName, defaultValue, null)
     {
     }
@@ -186,7 +186,7 @@ public sealed record JobListTemplateParameter : TemplateParameter<ConditionedLis
     public override string Type => "jobList";
 }
 
-public sealed record DeploymentTemplateParameter : TemplateParameter<DeploymentJob>
+public sealed record DeploymentParameter : Parameter<DeploymentJob>
 {
     /// <summary>
     /// Define a template parameter
@@ -194,7 +194,7 @@ public sealed record DeploymentTemplateParameter : TemplateParameter<DeploymentJ
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="displayName">Display name of the parameter in case this is a pipeline parameter</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    internal DeploymentTemplateParameter(string name, string? displayName, DeploymentJob? defaultValue = null)
+    internal DeploymentParameter(string name, string? displayName = null, DeploymentJob? defaultValue = null)
         : base(name, displayName, defaultValue, null)
     {
     }
@@ -202,7 +202,7 @@ public sealed record DeploymentTemplateParameter : TemplateParameter<DeploymentJ
     public override string Type => "deployment";
 }
 
-public sealed record DeploymentListTemplateParameter : TemplateParameter<ConditionedList<DeploymentJob>>
+public sealed record DeploymentListParameter : Parameter<ConditionedList<DeploymentJob>>
 {
     /// <summary>
     /// Define a template parameter
@@ -210,7 +210,7 @@ public sealed record DeploymentListTemplateParameter : TemplateParameter<Conditi
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="displayName">Display name of the parameter in case this is a pipeline parameter</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    internal DeploymentListTemplateParameter(string name, string? displayName, ConditionedList<DeploymentJob>? defaultValue = null)
+    internal DeploymentListParameter(string name, string? displayName = null, ConditionedList<DeploymentJob>? defaultValue = null)
         : base(name, displayName, defaultValue, null)
     {
     }
@@ -218,7 +218,7 @@ public sealed record DeploymentListTemplateParameter : TemplateParameter<Conditi
     public override string Type => "deploymentList";
 }
 
-public sealed record StageTemplateParameter : TemplateParameter<Stage>
+public sealed record StageParameter : Parameter<Stage>
 {
     /// <summary>
     /// Define a template parameter
@@ -226,7 +226,7 @@ public sealed record StageTemplateParameter : TemplateParameter<Stage>
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="displayName">Display name of the parameter in case this is a pipeline parameter</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    internal StageTemplateParameter(string name, string? displayName, Stage? defaultValue = null)
+    internal StageParameter(string name, string? displayName = null, Stage? defaultValue = null)
         : base(name, displayName, defaultValue, null)
     {
     }
@@ -234,7 +234,7 @@ public sealed record StageTemplateParameter : TemplateParameter<Stage>
     public override string Type => "stage";
 }
 
-public sealed record StageListTemplateParameter : TemplateParameter<ConditionedList<Stage>>
+public sealed record StageListParameter : Parameter<ConditionedList<Stage>>
 {
     /// <summary>
     /// Define a template parameter
@@ -242,7 +242,7 @@ public sealed record StageListTemplateParameter : TemplateParameter<ConditionedL
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="displayName">Display name of the parameter in case this is a pipeline parameter</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    internal StageListTemplateParameter(string name, string? displayName, ConditionedList<Stage>? defaultValue = null)
+    internal StageListParameter(string name, string? displayName = null, ConditionedList<Stage>? defaultValue = null)
         : base(name, displayName, defaultValue, null)
     {
     }
@@ -250,11 +250,11 @@ public sealed record StageListTemplateParameter : TemplateParameter<ConditionedL
     public override string Type => "stageList";
 }
 
-internal sealed record StageParameterReference : Stage, IYamlConvertible
+internal sealed record StageReference : Stage, IYamlConvertible
 {
     private readonly string _parameterName;
 
-    public StageParameterReference(string parameterName) : base(parameterName)
+    public StageReference(string parameterName) : base(parameterName)
     {
         _parameterName = parameterName;
     }
@@ -266,11 +266,11 @@ internal sealed record StageParameterReference : Stage, IYamlConvertible
         => emitter.Emit(new Scalar("${{ parameters." + _parameterName + " }}"));
 }
 
-internal sealed record JobParameterReference : JobBase, IYamlConvertible
+internal sealed record JobReference : JobBase, IYamlConvertible
 {
     private readonly string _parameterName;
 
-    public JobParameterReference(string parameterName) : base(parameterName)
+    public JobReference(string parameterName) : base(parameterName)
     {
         _parameterName = parameterName;
     }
@@ -282,11 +282,11 @@ internal sealed record JobParameterReference : JobBase, IYamlConvertible
         => emitter.Emit(new Scalar("${{ parameters." + _parameterName + " }}"));
 }
 
-internal sealed record StepParameterReference : Step, IYamlConvertible
+internal sealed record StepReference : Step, IYamlConvertible
 {
     private readonly string _parameterName;
 
-    public StepParameterReference(string parameterName)
+    public StepReference(string parameterName)
     {
         _parameterName = parameterName;
     }

--- a/src/Sharpliner/AzureDevOps/Pipeline.cs
+++ b/src/Sharpliner/AzureDevOps/Pipeline.cs
@@ -30,7 +30,7 @@ public abstract record PipelineBase
     /// More details can be found in <see href="https://docs.microsoft.com/en-us/azure/devops/pipelines/process/runtime-parameters?view=azure-devops">official Azure DevOps pipelines documentation</see>.
     /// </summary>
     [YamlMember(Order = 150)]
-    public ConditionedList<TemplateParameter> Parameters { get; init; } = new();
+    public ConditionedList<Parameter> Parameters { get; init; } = new();
 
     /// <summary>
     /// Specifies when the pipeline is supposed to run

--- a/src/Sharpliner/AzureDevOps/TemplateDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/TemplateDefinition.cs
@@ -17,8 +17,8 @@ public abstract class TemplateDefinition : AzureDevOpsDefinition
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
     /// <param name="allowedValues">Allowed list of values (for some data types)</param>
-    protected static TemplateParameter StringParameter(string name, string? defaultValue = null, IEnumerable<string>? allowedValues = null)
-        => new StringTemplateParameter(name, null, defaultValue, allowedValues);
+    protected static Parameter StringParameter(string name, string? defaultValue = null, IEnumerable<string>? allowedValues = null)
+        => new StringParameter(name, null, defaultValue, allowedValues);
 
     /// <summary>
     /// Defines a number template parameter
@@ -26,103 +26,103 @@ public abstract class TemplateDefinition : AzureDevOpsDefinition
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
     /// <param name="allowedValues">Allowed list of values (for some data types)</param>
-    protected static TemplateParameter NumberParameter(string name, int defaultValue = 0, IEnumerable<int>? allowedValues = null)
-        => new NumberTemplateParameter(name, null, defaultValue, allowedValues);
+    protected static Parameter NumberParameter(string name, int defaultValue = 0, IEnumerable<int>? allowedValues = null)
+        => new NumberParameter(name, null, defaultValue, allowedValues);
 
     /// <summary>
     /// Defines a boolean template parameter
     /// </summary>
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    protected static TemplateParameter BooleanParameter(string name, bool defaultValue = false)
-        => new BooleanTemplateParameter(name, null, defaultValue);
+    protected static Parameter BooleanParameter(string name, bool defaultValue = false)
+        => new BooleanParameter(name, null, defaultValue);
 
     /// <summary>
     /// Defines a object template parameter
     /// </summary>
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    protected static TemplateParameter ObjectParameter(string name, ConditionedDictionary? defaultValue = null)
-        => new ObjectTemplateParameter(name, null, defaultValue);
+    protected static Parameter ObjectParameter(string name, ConditionedDictionary? defaultValue = null)
+        => new ObjectParameter(name, null, defaultValue);
 
     /// <summary>
     /// Defines a step template parameter
     /// </summary>
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    protected static TemplateParameter StepParameter(string name, Step? defaultValue = null)
-        => new StepTemplateParameter(name, null, defaultValue);
+    protected static Parameter StepParameter(string name, Step? defaultValue = null)
+        => new StepParameter(name, null, defaultValue);
 
     /// <summary>
     /// Defines a stepList template parameter
     /// </summary>
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    protected static TemplateParameter StepListParameter(string name, ConditionedList<Step>? defaultValue = null)
-        => new StepListTemplateParameter(name, null, defaultValue);
+    protected static Parameter StepListParameter(string name, ConditionedList<Step>? defaultValue = null)
+        => new StepListParameter(name, null, defaultValue);
 
     /// <summary>
     /// Defines a job template parameter
     /// </summary>
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    protected static TemplateParameter JobParameter(string name, JobBase? defaultValue = null)
-        => new JobTemplateParameter(name, null, defaultValue);
+    protected static Parameter JobParameter(string name, JobBase? defaultValue = null)
+        => new JobParameter(name, null, defaultValue);
 
     /// <summary>
     /// Defines a jobList template parameter
     /// </summary>
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    protected static TemplateParameter JobListParameter(string name, ConditionedList<JobBase>? defaultValue = null)
-        => new JobListTemplateParameter(name, null, defaultValue);
+    protected static Parameter JobListParameter(string name, ConditionedList<JobBase>? defaultValue = null)
+        => new JobListParameter(name, null, defaultValue);
 
     /// <summary>
     /// Defines a deployment job template parameter
     /// </summary>
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    protected static TemplateParameter DeploymentParameter(string name, DeploymentJob? defaultValue = null)
-        => new DeploymentTemplateParameter(name, null, defaultValue);
+    protected static Parameter DeploymentParameter(string name, DeploymentJob? defaultValue = null)
+        => new DeploymentParameter(name, null, defaultValue);
 
     /// <summary>
     /// Defines a deploymentList template parameter
     /// </summary>
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    protected static TemplateParameter DeploymentListParameter(string name, ConditionedList<DeploymentJob>? defaultValue = null)
-        => new DeploymentListTemplateParameter(name, null, defaultValue);
+    protected static Parameter DeploymentListParameter(string name, ConditionedList<DeploymentJob>? defaultValue = null)
+        => new DeploymentListParameter(name, null, defaultValue);
 
     /// <summary>
     /// Defines a stage template parameter
     /// </summary>
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    protected static TemplateParameter StageParameter(string name, Stage? defaultValue = null)
-        => new StageTemplateParameter(name, null, defaultValue);
+    protected static Parameter StageParameter(string name, Stage? defaultValue = null)
+        => new StageParameter(name, null, defaultValue);
 
     /// <summary>
     /// Defines a stageList template parameter
     /// </summary>
     /// <param name="name">Name of the parameter, can be referenced in the template as ${{ parameters.name }}</param>
     /// <param name="defaultValue">Default value; if no default, then the parameter MUST be given by the user at runtime</param>
-    protected static TemplateParameter StageListParameter(string name, ConditionedList<Stage>? defaultValue = null)
-        => new StageListTemplateParameter(name, null, defaultValue);
+    protected static Parameter StageListParameter(string name, ConditionedList<Stage>? defaultValue = null)
+        => new StageListParameter(name, null, defaultValue);
 
     /// <summary>
     /// Allows the ${{ parameters.name }} notation for a stage defined in parameters.
     /// </summary>
-    protected static Stage StageParameterReference(string parameterName) => new StageParameterReference(parameterName);
+    protected static Stage StageParameterReference(string parameterName) => new StageReference(parameterName);
 
     /// <summary>
     /// Allows the ${{ parameters.name }} notation for a job defined in parameters.
     /// </summary>
-    protected static JobBase JobParameterReference(string parameterName) => new JobParameterReference(parameterName);
+    protected static JobBase JobParameterReference(string parameterName) => new JobReference(parameterName);
 
     /// <summary>
     /// Allows the ${{ parameters.name }} notation for a step defined in parameters.
     /// </summary>
-    protected static Step StepParameterReference(string parameterName) => new StepParameterReference(parameterName);
+    protected static Step StepParameterReference(string parameterName) => new StepReference(parameterName);
 
     public sealed class TemplateParameterReference
     {
@@ -146,7 +146,7 @@ public abstract class TemplateDefinition<T> : TemplateDefinition, ISharplinerDef
     public virtual TargetPathType TargetPathType => TargetPathType.RelativeToCurrentDir;
 
     [DisallowNull]
-    public virtual List<TemplateParameter> Parameters { get; } = new();
+    public virtual List<Parameter> Parameters { get; } = new();
 
     [DisallowNull]
     public abstract ConditionedList<T> Definition { get; }

--- a/src/Sharpliner/AzureDevOps/TemplateDefinitionCollection.cs
+++ b/src/Sharpliner/AzureDevOps/TemplateDefinitionCollection.cs
@@ -18,7 +18,7 @@ namespace Sharpliner.AzureDevOps;
 public record TemplateDefinitionData<T>(
     string TargetFile,
     ConditionedList<T> Definition,
-    List<TemplateParameter>? Parameters = null,
+    List<Parameter>? Parameters = null,
     TargetPathType PathType = TargetPathType.RelativeToGitRoot,
     string[]? Header = null);
 
@@ -52,7 +52,7 @@ internal class TemplateDefinitionWrapper<T> : TemplateDefinition<T>
         TargetFile = data.TargetFile;
         Definition = data.Definition;
         TargetPathType = data.PathType;
-        Parameters = data.Parameters ?? new List<TemplateParameter>();
+        Parameters = data.Parameters ?? new List<Parameter>();
         _header = data.Header ?? SharplinerPublisher.GetDefaultHeader(definitionType);
         YamlProperty = yamlMemberName;
         Validations = validations;
@@ -64,7 +64,7 @@ internal class TemplateDefinitionWrapper<T> : TemplateDefinition<T>
 
     public override ConditionedList<T> Definition { get; }
 
-    public override List<TemplateParameter> Parameters { get; }
+    public override List<Parameter> Parameters { get; }
 
     public override string[]? Header => _header;
 

--- a/tests/Sharpliner.Tests/AzureDevOps/TemplateTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/TemplateTests.cs
@@ -50,7 +50,7 @@ public class TemplateTests
     {
         public override string TargetFile => "template.yml";
 
-        public override List<TemplateParameter> Parameters => new()
+        public override List<Parameter> Parameters => new()
         {
             StringParameter("project"),
             StringParameter("version", allowedValues: new[] { "5.0.100", "5.0.102" }),


### PR DESCRIPTION
Related to the discussion in #208:
- Internal rename of classes since we use parameters even in pipelines and not just templates
- Make display name optional for pipeline parameters