### PR TITLE
Fix the download task

### DIFF
--- a/docs/AzureDevOps/DefinitionReference.md
+++ b/docs/AzureDevOps/DefinitionReference.md
@@ -50,6 +50,13 @@ Steps =
 {
     Checkout.Self,
 
+    Download.LatestFromBranch("internal", 23, "refs/heads/develop", artifact: "CLI.Package") with
+    {
+        AllowPartiallySucceededBuilds = true,
+        CheckDownloadedFiles = true,
+        PreferTriggeringPipeline = true,
+    }
+
     // Tasks are represented as C# records so you can use the `with` keyword to override the properties
     DotNet.Build("src/MyProject.sln", includeNuGetOrg: true) with
     {

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/AzureDevOpsTask.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/AzureDevOpsTask.cs
@@ -67,6 +67,9 @@ public record AzureDevOpsTask : Step
     protected string? GetString(string name, string? defaultValue = null)
         => Inputs.TryGetValue(name, out var value) ? value.ToString() : defaultValue;
 
+    protected int? GetInt(string name, int? defaultValue = null)
+        => Inputs.TryGetValue(name, out var value) ? int.Parse(value.ToString()!) : defaultValue;
+
     protected bool GetBool(string name, bool defaultValue)
         => Inputs.TryGetValue(name, out var value) ? value.ToString() == "true" : defaultValue;
 

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/DownloadTaskBuilder.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/DownloadTaskBuilder.cs
@@ -1,4 +1,7 @@
-﻿namespace Sharpliner.AzureDevOps.Tasks;
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Sharpliner.AzureDevOps.Tasks;
 
 public class DownloadTaskBuilder
 {
@@ -15,7 +18,70 @@ public class DownloadTaskBuilder
     /// <summary>
     /// Creates a download task that an artifact from a given pipeline run.
     /// </summary>
-    public SpecificDownloadTask SpecificBuild(string project, int definition) => new(project, definition);
+    /// <param name="project">The project GUID from which to download the pipeline artifacts.</param>
+    /// <param name="definition">The definition ID of the build pipeline.</param>
+    /// <param name="buildId">The build from which to download the artifacts. For example: 1764</param>
+    /// <param name="artifact">The name of the artifact to download. If left empty, all artifacts associated to the pipeline run will be downloaded.</param>
+    /// <param name="path">
+    /// Directory to download the artifact files. Can be relative to the pipeline workspace directory or absolute.
+    /// If multi-download option is applied (by leaving an empty artifact name), a sub-directory will be created for each.
+    /// Default value: $(Pipeline.Workspace)
+    /// More details can be found in <see href="https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops">official Azure DevOps pipelines documentation</see>.
+    /// </param>
+    /// <param name="patterns">
+    /// One or more file matching patterns that limit which files get downloaded.
+    /// Default value: **
+    /// More details can be found in <see href="https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/file-matching-patterns?view=azure-devops">official Azure DevOps pipelines documentation</see>.
+    /// </param>
+    public SpecificDownloadTask SpecificBuild(
+        string project,
+        int definition,
+        int buildId,
+        string? artifact = null,
+        string? path = null,
+        IEnumerable<string>? patterns = null)
+        =>
+        new(RunVersion.Specific, project, definition)
+        {
+            BuildId = buildId,
+            Artifact = artifact,
+            Path = path,
+            Patterns = patterns?.ToList()
+        };
+
+    /// <summary>
+    /// Creates a download task that an artifact from a given pipeline run.
+    /// </summary>
+    /// <param name="project">The project GUID from which to download the pipeline artifacts.</param>
+    /// <param name="definition">The definition ID of the build pipeline.</param>
+    /// <param name="branchName">Specify to filter on branch/ref name. Default value: refs/heads/master</param>
+    /// <param name="artifact">The name of the artifact to download. If left empty, all artifacts associated to the pipeline run will be downloaded.</param>
+    /// <param name="path">
+    /// Directory to download the artifact files. Can be relative to the pipeline workspace directory or absolute.
+    /// If multi-download option is applied (by leaving an empty artifact name), a sub-directory will be created for each.
+    /// Default value: $(Pipeline.Workspace)
+    /// More details can be found in <see href="https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops">official Azure DevOps pipelines documentation</see>.
+    /// </param>
+    /// <param name="patterns">
+    /// One or more file matching patterns that limit which files get downloaded.
+    /// Default value: **
+    /// More details can be found in <see href="https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/file-matching-patterns?view=azure-devops">official Azure DevOps pipelines documentation</see>.
+    /// </param>
+    public SpecificDownloadTask LatestFromBranch(
+        string project,
+        int definition,
+        string? branchName = null,
+        string? artifact = null,
+        string? path = null,
+        IEnumerable<string>? patterns = null)
+        =>
+        new(RunVersion.LatestFromBranch, project, definition)
+        {
+            BranchName = branchName,
+            Artifact = artifact,
+            Path = path,
+            Patterns = patterns?.ToList()
+        };
 
     internal DownloadTaskBuilder()
     {

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/DownloadTaskBuilder.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/DownloadTaskBuilder.cs
@@ -2,12 +2,20 @@
 
 public class DownloadTaskBuilder
 {
+    /// <summary>
+    /// Creates a download task that downloads artifacts from the current build.
+    /// </summary>
     public CurrentDownloadTask Current => new();
 
+    /// <summary>
+    /// Creates a download task that skips downloading artifacts for the current job.
+    /// </summary>
     public NoneDownloadTask None => new();
 
-    /// <param name="pipelineResourceIdentifier">The definition ID of the build pipeline.</param>
-    public SpecificDownloadTask SpecificBuild(string pipelineResourceIdentifier) => new(pipelineResourceIdentifier);
+    /// <summary>
+    /// Creates a download task that an artifact from a given pipeline run.
+    /// </summary>
+    public SpecificDownloadTask SpecificBuild(string project, int definition) => new(project, definition);
 
     internal DownloadTaskBuilder()
     {

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/DownloadTask.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/DownloadTask.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using YamlDotNet.Serialization;
@@ -41,14 +42,6 @@ public abstract record DownloadTask : Step
     public string Path { get; init; } = "$(Pipeline.Workspace)";
 
     /// <summary>
-    /// A boolean specifying whether to download artifacts from a triggering build.
-    /// Defaults to false.
-    /// </summary>
-    [YamlMember(Order = 100)]
-    [DefaultValue(false)]
-    public bool PreferTriggeringPipeline { get; init; } = false;
-
-    /// <summary>
     /// A list of tags. Only builds with these tags will be returned.
     /// </summary>
     [YamlIgnore]
@@ -56,26 +49,11 @@ public abstract record DownloadTask : Step
 
     [YamlMember(Alias = "tags", Order = 104)]
     public string? _Tags => Tags.Any() ? string.Join(",", Tags) : null;
-
-    /// <summary>
-    /// If checked, this build task will try to download artifacts whether the build is succeeded or partially succeeded.
-    /// Defaults to false.
-    /// </summary>
-    [YamlMember(Order = 105)]
-    [DefaultValue(false)]
-    public bool AllowPartiallySucceededBuilds { get; init; } = false;
-
-    /// <summary>
-    /// If checked, this build task will try to download artifacts whether the build is succeeded or failed.
-    /// Defaults to false.
-    /// </summary>
-    [YamlMember(Order = 106)]
-    [DefaultValue(false)]
-    public bool AllowFailedBuilds { get; init; } = false;
 }
 
 public record CurrentDownloadTask : DownloadTask
 {
+    [YamlMember(Order = 1)]
     public override string Download => "current";
 }
 
@@ -85,50 +63,173 @@ public record NoneDownloadTask : Step
     public string Download => "none";
 }
 
-public record SpecificDownloadTask : DownloadTask
+public record SpecificDownloadTask : AzureDevOpsTask
 {
-    private readonly string _pipelineResourceIdentifier;
+    private const string ProjectProperty = "project";
+    private const string PipelineProperty = "pipeline";
+    private const string RunVersionProperty = "runVersion";
+    private const string RunBranchProperty = "runBranch";
+    private const string RunIdProperty = "runId";
+    private const string TagsProperty = "tags";
+    private const string PreferTriggeringPipelineProperty = "preferTriggeringPipeline";
+    private const string AllowPartiallySucceededBuildsProperty = "allowPartiallySucceededBuilds";
+    private const string AllowFailedBuildsProperty = "allowFailedBuilds";
+    private const string CheckDownloadedFilesProperty = "checkDownloadedFiles";
+    private const string RetryDownloadCountProperty = "retryDownloadCount";
 
-    public override string Download => _pipelineResourceIdentifier;
+    public SpecificDownloadTask(string project, int pipeline) : base("DownloadPipelineArtifact@2")
+    {
+        SetProperty(RunVersionProperty, "specific");
+        Project = project;
+        Pipeline = pipeline;
+    }
 
     /// <summary>
     /// The project GUID from which to download the pipeline artifacts.
     /// </summary>
-    [YamlMember(Order = 64)]
-    public string? Project { get; init; }
+    [YamlIgnore]
+    public string Project
+    {
+        get => GetString(ProjectProperty) ?? throw new NullReferenceException();
+        init => SetProperty(ProjectProperty, value);
+    }
 
     /// <summary>
-    /// Specifies which build version to download.
+    /// The definition ID of the build pipeline.
     /// </summary>
     [YamlIgnore]
-    public RunVersion RunVersion { get; init; }
-
-    [YamlMember(Alias = "runVersion", Order = 65)]
-    public string _RunVersion => RunVersion switch
+    public int Pipeline
     {
-        RunVersion.LatestFromBranch => "latestFromBranch",
-        RunVersion.Specific => "specific",
-        _ => "latest",
-    };
+        get => GetInt(PipelineProperty) ?? 0;
+        init => SetProperty(PipelineProperty, value.ToString());
+    }
+
+    [YamlIgnore]
+    public RunVersion RunVersion { get; } = RunVersion.Specific;
 
     /// <summary>
     /// Specify to filter on branch/ref name.
     /// For example: refs/heads/develop
+    /// Argument aliases: branchName
     /// </summary>
-    [YamlMember(Alias = "runBranch", Order = 66)]
-    [DefaultValue("refs/heads/master")]
-    public string BranchName { get; init; } = "refs/heads/master";
+    [YamlIgnore]
+    public string RunBranch
+    {
+        get => GetString(RunBranchProperty)!;
+        init => SetProperty(RunBranchProperty, value);
+    }
+
+    /// <summary>
+    /// Specify to filter on branch/ref name.
+    /// For example: refs/heads/develop
+    /// Argument aliases: runBranch
+    /// </summary>
+    [YamlIgnore]
+    public string BranchName
+    {
+        get => GetString(RunBranchProperty)!;
+        init => SetProperty(RunBranchProperty, value);
+    }
 
     /// <summary>
     /// The build from which to download the artifacts.
     /// For example: 1764
+    /// Argument aliases: pipelineId, buildId
     /// </summary>
-    [YamlMember(Alias = "runId", Order = 67)]
-    public int PipelineId { get; init; }
-
-    public SpecificDownloadTask(string pipelineResourceIdentifier)
+    [YamlIgnore]
+    public int RunId
     {
-        _pipelineResourceIdentifier = pipelineResourceIdentifier;
+        get => GetInt(RunIdProperty) ?? 0;
+        init => SetProperty(RunIdProperty, value.ToString());
+    }
+
+    /// <summary>
+    /// The build from which to download the artifacts.
+    /// For example: 1764
+    /// Argument aliases: runId, buildId
+    /// </summary>
+    [YamlIgnore]
+    public int PipelineId
+    {
+        get => GetInt(RunIdProperty) ?? 0;
+        init => SetProperty(RunIdProperty, value.ToString());
+    }
+
+    /// <summary>
+    /// The build from which to download the artifacts.
+    /// For example: 1764
+    /// Argument aliases: runId, pipelineId
+    /// </summary>
+    [YamlIgnore]
+    public int BuildId
+    {
+        get => GetInt(RunIdProperty) ?? 0;
+        init => SetProperty(RunIdProperty, value.ToString());
+    }
+
+    /// <summary>
+    /// A list of tags. Only builds with these tags will be returned.
+    /// </summary>
+    [YamlIgnore]
+    public List<string> Tags
+    {
+        get => (GetString(TagsProperty) ?? string.Empty).Split(",").ToList();
+        init => SetProperty(TagsProperty, string.Join(",", value));
+    }
+
+    /// <summary>
+    /// A boolean specifying whether to download artifacts from a triggering build.
+    /// Defaults to false.
+    /// </summary>
+    [YamlIgnore]
+    public bool PreferTriggeringPipeline
+    {
+        get => GetBool(PreferTriggeringPipelineProperty, false);
+        init => SetProperty(PreferTriggeringPipelineProperty, value ? "true" : "false");
+    }
+
+    /// <summary>
+    /// If checked, this build task will try to download artifacts whether the build is succeeded or partially succeeded.
+    /// Defaults to false.
+    /// </summary>
+    [YamlIgnore]
+    public bool AllowPartiallySucceededBuilds
+    {
+        get => GetBool(AllowPartiallySucceededBuildsProperty, false);
+        init => SetProperty(AllowPartiallySucceededBuildsProperty, value ? "true" : "false");
+    }
+
+    /// <summary>
+    /// If checked, this build task will try to download artifacts whether the build is succeeded or failed.
+    /// Defaults to false.
+    /// </summary>
+    [YamlIgnore]
+    public bool AllowFailedBuilds
+    {
+        get => GetBool(AllowFailedBuildsProperty, false);
+        init => SetProperty(AllowFailedBuildsProperty, value ? "true" : "false");
+    }
+
+    /// <summary>
+    /// A boolean specifying whether this build task will check that all files are fully downloaded.
+    /// Defaults to false.
+    /// </summary>
+    [YamlIgnore]
+    public bool CheckDownloadedFiles
+    {
+        get => GetBool(CheckDownloadedFilesProperty, false);
+        init => SetProperty(CheckDownloadedFilesProperty, value ? "true" : "false");
+    }
+
+    /// <summary>
+    /// Number of times to retry downloading a build artifact if the download fails.
+    /// Defaults to 4.
+    /// </summary>
+    [YamlIgnore]
+    public int RetryDownloadCount
+    {
+        get => GetInt(RetryDownloadCountProperty) ?? 0;
+        init => SetProperty(RetryDownloadCountProperty, value.ToString());
     }
 }
 

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/DownloadTask.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/DownloadTask.cs
@@ -119,8 +119,8 @@ public record SpecificDownloadTask : AzureDevOpsTask
     [YamlIgnore]
     public List<string>? Patterns
     {
-        get => (GetString(PatternsProperty) ?? string.Empty).Split("\n").ToList();
-        init => SetProperty(PatternsProperty, value is null || value.Count == 0 ? null : string.Join("\n", value));
+        get => (GetString(PatternsProperty) ?? string.Empty).Split(System.Environment.NewLine).ToList();
+        init => SetProperty(PatternsProperty, value is null || value.Count == 0 ? null : string.Join(System.Environment.NewLine, value));
     }
 
     /// <summary>

--- a/src/Sharpliner/MultilineStringEmitter.cs
+++ b/src/Sharpliner/MultilineStringEmitter.cs
@@ -1,0 +1,39 @@
+﻿using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.EventEmitters;
+
+namespace Sharpliner;
+
+/// <summary>
+/// This makes sure that multiline strings get serialized properly.
+/// That means using `|` and not `>` (which glues lines together).
+/// </summary>
+public class MultilineStringEmitter : ChainedEventEmitter
+{
+    public MultilineStringEmitter(IEventEmitter nextEmitter)
+        : base(nextEmitter)
+    {
+    }
+
+    public override void Emit(ScalarEventInfo eventInfo, IEmitter emitter)
+    {
+
+        if (typeof(string).IsAssignableFrom(eventInfo.Source.Type))
+        {
+            string? value = eventInfo.Source.Value as string;
+            if (!string.IsNullOrEmpty(value))
+            {
+                bool isMultiLine = value.IndexOfAny(new char[] { '\r', '\n' }) >= 0;
+                if (isMultiLine)
+                {
+                    eventInfo = new ScalarEventInfo(eventInfo.Source)
+                    {
+                        Style = ScalarStyle.Literal
+                    };
+                }
+            }
+        }
+
+        nextEmitter.Emit(eventInfo, emitter);
+    }
+}

--- a/src/Sharpliner/SharplinerSerializer.cs
+++ b/src/Sharpliner/SharplinerSerializer.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Text.RegularExpressions;
+using YamlDotNet.Core;
 using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.EventEmitters;
 using YamlDotNet.Serialization.NamingConventions;
 
 namespace Sharpliner;
@@ -19,7 +21,8 @@ public static class SharplinerSerializer
     {
         var serializerBuilder = new SerializerBuilder()
             .WithNamingConvention(CamelCaseNamingConvention.Instance)
-            .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitDefaults | DefaultValuesHandling.OmitEmptyCollections);
+            .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitDefaults | DefaultValuesHandling.OmitEmptyCollections)
+            .WithEventEmitter(nextEmitter => new MultilineStringEmitter(nextEmitter));
 
         return serializerBuilder.Build();
     }

--- a/tests/Sharpliner.Tests/AzureDevOps/Model/Tasks/TaskBuilderTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/Model/Tasks/TaskBuilderTests.cs
@@ -289,12 +289,18 @@ public class TaskBuilderTests
                                 "frontend.config",
                             }
                         },
-                        Download.SpecificBuild("public", 56) with
+                        Download.SpecificBuild("public", 56, 1745, "MyProject.CLI", patterns: new[] { "**/*.dll", "**/*.exe" }) with
                         {
-                            BranchName = "main",
                             AllowPartiallySucceededBuilds = true,
                             RetryDownloadCount = 3,
                             Tags = new() { "non-release", "preview" },
+                        },
+                        Download.LatestFromBranch("internal", 23, "refs/heads/develop", path: variables.Build.ArtifactStagingDirectory) with
+                        {
+                            AllowFailedBuilds = true,
+                            CheckDownloadedFiles = true,
+                            PreferTriggeringPipeline = true,
+                            Artifact = "Another.CLI",
                         }
                     }
                 }
@@ -326,10 +332,26 @@ public class TaskBuilderTests
                   runVersion: specific
                   project: public
                   pipeline: 56
-                  runBranch: main
+                  runId: 1745
+                  artifact: MyProject.CLI
+                  patterns: |-
+                    **/*.dll
+                    **/*.exe
                   allowPartiallySucceededBuilds: true
                   retryDownloadCount: 3
                   tags: non-release,preview
+
+            - task: DownloadPipelineArtifact@2
+                inputs:
+                  runVersion: latestFromBranch
+                  project: internal
+                  pipeline: 23
+                  runBranch: refs/heads/develop
+                  path: $(Build.ArtifactStagingDirectory)
+                  allowFailedBuilds: true
+                  checkDownloadedFiles: true
+                  preferTriggeringPipeline: true
+                  artifact: Another.CLI
             """);
     }
 

--- a/tests/Sharpliner.Tests/AzureDevOps/Model/Tasks/TaskBuilderTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/Model/Tasks/TaskBuilderTests.cs
@@ -341,7 +341,7 @@ public class TaskBuilderTests
                   retryDownloadCount: 3
                   tags: non-release,preview
 
-            - task: DownloadPipelineArtifact@2
+              - task: DownloadPipelineArtifact@2
                 inputs:
                   runVersion: latestFromBranch
                   project: internal

--- a/tests/Sharpliner.Tests/AzureDevOps/Model/Tasks/TaskBuilderTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/Model/Tasks/TaskBuilderTests.cs
@@ -282,7 +282,6 @@ public class TaskBuilderTests
                                 "release",
                                 "nightly",
                             },
-                            AllowFailedBuilds = true,
                             Artifact = "Frontend",
                             Patterns = new()
                             {
@@ -290,12 +289,12 @@ public class TaskBuilderTests
                                 "frontend.config",
                             }
                         },
-                        Download.SpecificBuild("dotnet-xharness") with
+                        Download.SpecificBuild("public", 56) with
                         {
-                            RunVersion = RunVersion.Latest,
-                            Project = "2a73171e-15d1-41f9-b283-49aa0633d1a2",
                             BranchName = "main",
-                            Path = "$(Pipeline.Workspace)/xharness"
+                            AllowPartiallySucceededBuilds = true,
+                            RetryDownloadCount = 3,
+                            Tags = new() { "non-release", "preview" },
                         }
                     }
                 }
@@ -321,13 +320,16 @@ public class TaskBuilderTests
                   frontend/**/*
                   frontend.config
                 tags: release,nightly
-                allowFailedBuilds: true
 
-              - download: dotnet-xharness
-                path: $(Pipeline.Workspace)/xharness
-                project: 2a73171e-15d1-41f9-b283-49aa0633d1a2
-                runVersion: latest
-                runBranch: main
+              - task: DownloadPipelineArtifact@2
+                inputs:
+                  runVersion: specific
+                  project: public
+                  pipeline: 56
+                  runBranch: main
+                  allowPartiallySucceededBuilds: true
+                  retryDownloadCount: 3
+                  tags: non-release,preview
             """);
     }
 


### PR DESCRIPTION
- When specifying the `download: none` and `download: current`, uses the shorthand YAML style
    https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/steps-download?view=azure-pipelines
- When utilizing specific build / latest from branch, uses the full task with all available properties
    https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/download-pipeline-artifact?view=azure-devops
- Improves the builder for better UX

Fixes #202 