### PR TITLE
Change built-in variables to strong-typed objects

### DIFF
--- a/src/Sharpliner/AzureDevOps/VariablesReference.cs
+++ b/src/Sharpliner/AzureDevOps/VariablesReference.cs
@@ -44,18 +44,18 @@ public sealed class VariablesReference
     /// Set to True if the script is being run by a build task.
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// </summary>
-    public string TF_BUILD => VariableReferenceBase.GetReference(string.Empty, "TF_BUILD");
+    public VariableReference TF_BUILD => VariableReferenceBase.GetReference(string.Empty, "TF_BUILD");
 
-    public string Configuration => VariableReferenceBase.GetReference(string.Empty, "Configuration");
+    public VariableReference Configuration => VariableReferenceBase.GetReference(string.Empty, "Configuration");
 }
 
 public abstract class VariableReferenceBase
 {
-    internal static string GetReference(string prefix, string variableName) => $"$({prefix}{variableName})";
+    internal static VariableReference GetReference(string prefix, string variableName) => new($"{prefix}{variableName}");
 
-    public string this[string variableName] => GetReference(Prefix, variableName);
+    public VariableReference this[string variableName] => GetReference(Prefix, variableName);
 
-    protected string GetReference(string name) => GetReference(Prefix, name);
+    protected VariableReference GetReference(string name) => GetReference(Prefix, name);
 
     protected abstract string Prefix { get; }
 }
@@ -73,7 +73,7 @@ public sealed class AgentVariableReference : VariableReferenceBase
     /// This variable has the same value as Pipeline.Workspace.
     /// For example: /home/vsts/work/1
     /// </summary>
-    public string BuildDirectory => GetReference("BuildDirectory");
+    public VariableReference BuildDirectory => GetReference("BuildDirectory");
 
     /// <summary>
     /// A mapping from container resource names in YAML to their Docker IDs at runtime.
@@ -87,24 +87,24 @@ public sealed class AgentVariableReference : VariableReferenceBase
     ///   }
     /// }
     /// </summary>
-    public string ContainerMapping => GetReference("ContainerMapping");
+    public VariableReference ContainerMapping => GetReference("ContainerMapping");
 
     /// <summary>
     /// The directory the agent is installed into. This contains the agent software.
     /// For example: c:\agent.
     /// </summary>
-    public string HomeDirectory => GetReference("HomeDirectory");
+    public VariableReference HomeDirectory => GetReference("HomeDirectory");
 
     /// <summary>
     /// The ID of the agent.
     /// </summary>
-    public string Id => GetReference("Id");
+    public VariableReference Id => GetReference("Id");
 
     /// <summary>
     /// The name of the running job.
     /// This will usually be "Job" or "__default", but in multi-config scenarios, will be the configuration.
     /// </summary>
-    public string JobName => GetReference("JobName");
+    public VariableReference JobName => GetReference("JobName");
 
     /// <summary>
     /// The status of the build.
@@ -113,18 +113,18 @@ public sealed class AgentVariableReference : VariableReferenceBase
     ///   - Succeeded
     ///   - SucceededWithIssues (partially successful)
     /// </summary>
-    public string JobStatus => GetReference("JobStatus");
+    public VariableReference JobStatus => GetReference("JobStatus");
 
     /// <summary>
     /// The name of the machine on which the agent is installed.
     /// </summary>
-    public string MachineName => GetReference("MachineName");
+    public VariableReference MachineName => GetReference("MachineName");
 
     /// <summary>
     /// The name of the agent that is registered with the pool.
     /// If you are using a self-hosted agent, then this name is specified by you. See agents.
     /// </summary>
-    public string Name => GetReference("Name");
+    public VariableReference Name => GetReference("Name");
 
     /// <summary>
     /// The operating system of the agent host.
@@ -133,7 +133,7 @@ public sealed class AgentVariableReference : VariableReferenceBase
     ///   - Darwin
     ///   - Linux
     /// </summary>
-    public string OS => GetReference("OS");
+    public VariableReference OS => GetReference("OS");
 
     /// <summary>
     /// The operating system processor architecture of the agent host.
@@ -142,28 +142,28 @@ public sealed class AgentVariableReference : VariableReferenceBase
     ///   - X64
     ///   - ARM
     /// </summary>
-    public string OSArchitecture => GetReference("OSArchitecture");
+    public VariableReference OSArchitecture => GetReference("OSArchitecture");
 
     /// <summary>
     /// A temporary folder that is cleaned after each pipeline job.
     /// This directory is used by tasks such as .NET Core CLI task to hold temporary items like test results before they are published.
     /// For example: /home/vsts/work/_temp for Ubuntu
     /// </summary>
-    public string TempDirectory => GetReference("TempDirectory");
+    public VariableReference TempDirectory => GetReference("TempDirectory");
 
     /// <summary>
     /// The directory used by tasks such as Node Tool Installer and Use Python Version to switch between multiple versions of a tool.
     /// These tasks will add tools from this directory to PATH so that subsequent build steps can use them.
     /// Learn about managing this directory on a self-hosted agent.
     /// </summary>
-    public string ToolsDirectory => GetReference("ToolsDirectory");
+    public VariableReference ToolsDirectory => GetReference("ToolsDirectory");
 
     /// <summary>
     /// The working directory for this agent.
     /// For example: c:\agent_work
     /// Note: This directory is not guaranteed to be writable by pipeline tasks (eg. when mapped into a container)
     /// </summary>
-    public string WorkFolder => GetReference("WorkFolder");
+    public VariableReference WorkFolder => GetReference("WorkFolder");
 }
 
 public sealed class BuildVariableReference : VariableReferenceBase
@@ -186,7 +186,7 @@ public sealed class BuildVariableReference : VariableReferenceBase
     ///
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// </summary>
-    public string ArtifactStagingDirectory => GetReference("ArtifactStagingDirectory");
+    public VariableReference ArtifactStagingDirectory => GetReference("ArtifactStagingDirectory");
 
     /// <summary>
     /// The local path on the agent where any artifacts are copied to before being pushed to their destination.
@@ -196,12 +196,12 @@ public sealed class BuildVariableReference : VariableReferenceBase
     /// See Artifacts in Azure Pipelines.
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// </summary>
-    public string StagingDirectory => GetReference("StagingDirectory");
+    public VariableReference StagingDirectory => GetReference("StagingDirectory");
 
     /// <summary>
     /// The ID of the record for the completed build.
     /// </summary>
-    public string BuildId => GetReference("BuildId");
+    public VariableReference BuildId => GetReference("BuildId");
 
     /// <summary>
     /// The name of the completed build, also known as the run number.You can specify what is included in this value.
@@ -211,7 +211,7 @@ public sealed class BuildVariableReference : VariableReferenceBase
     ///
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// </summary>
-    public string BuildNumber => GetReference("BuildNumber");
+    public VariableReference BuildNumber => GetReference("BuildNumber");
 
     /// <summary>
     /// The URI for the build.
@@ -219,7 +219,7 @@ public sealed class BuildVariableReference : VariableReferenceBase
     ///
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// </summary>
-    public string BuildUri => GetReference("BuildUri");
+    public VariableReference BuildUri => GetReference("BuildUri");
 
     /// <summary>
     /// The local path on the agent you can use as an output folder for compiled binaries.
@@ -228,35 +228,35 @@ public sealed class BuildVariableReference : VariableReferenceBase
     ///
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// </summary>
-    public string BinariesDirectory => GetReference("BinariesDirectory");
+    public VariableReference BinariesDirectory => GetReference("BinariesDirectory");
 
     /// <summary>
     /// The ID of the container for your artifact.
     /// When you upload an artifact in your pipeline, it is added to a container that is specific for that particular artifact.
     /// </summary>
-    public string ContainerId => GetReference("ContainerId");
+    public VariableReference ContainerId => GetReference("ContainerId");
 
     /// <summary>
     /// The name of the build pipeline.
     /// Note: This value can contain whitespace or other invalid label characters. In these cases, the label format will fail.
     /// </summary>
-    public string DefinitionName => GetReference("DefinitionName");
+    public VariableReference DefinitionName => GetReference("DefinitionName");
 
     /// <summary>
     /// The version of the build pipeline.
     /// </summary>
-    public string DefinitionVersion => GetReference("DefinitionVersion");
+    public VariableReference DefinitionVersion => GetReference("DefinitionVersion");
 
     /// <summary>
     /// See "How are the identity variables set?".
     /// Note: This value can contain whitespace or other invalid label characters. In these cases, the label format will fail.
     /// </summary>
-    public string QueuedBy => GetReference("QueuedBy");
+    public VariableReference QueuedBy => GetReference("QueuedBy");
 
     /// <summary>
     /// See "How are the identity variables set?"
     /// </summary>
-    public string QueuedById => GetReference("QueuedById");
+    public VariableReference QueuedById => GetReference("QueuedById");
 
     /// <summary>
     /// The event that caused the build to run.
@@ -269,7 +269,7 @@ public sealed class BuildVariableReference : VariableReferenceBase
     ///   - PullRequest: The build was triggered by a Git branch policy that requires a build.
     ///   - ResourceTrigger: The build was triggered by a resource trigger or it was triggered by another build.
     /// </summary>
-    public string Reason => GetReference("Reason");
+    public VariableReference Reason => GetReference("Reason");
 
     /// <summary>
     /// Variables connected to repository information
@@ -280,17 +280,17 @@ public sealed class BuildVariableReference : VariableReferenceBase
     /// See "How are the identity variables set?"
     /// Note: This value can contain whitespace or other invalid label characters. In these cases, the label format will fail.
     /// </summary>
-    public string RequestedFor => GetReference("RequestedFor");
+    public VariableReference RequestedFor => GetReference("RequestedFor");
 
     /// <summary>
     /// See "How are the identity variables set?"
     /// </summary>
-    public string RequestedForEmail => GetReference("RequestedForEmail");
+    public VariableReference RequestedForEmail => GetReference("RequestedForEmail");
 
     /// <summary>
     /// See "How are the identity variables set?"
     /// </summary>
-    public string RequestedForId => GetReference("RequestedForId");
+    public VariableReference RequestedForId => GetReference("RequestedForId");
 
     /// <summary>
     /// The branch of the triggering repo the build was queued for.
@@ -305,7 +305,7 @@ public sealed class BuildVariableReference : VariableReferenceBase
     /// When you use this variable in your build number format, the forward slash characters (/) are replaced with underscore characters _).
     /// Note: In TFVC, if you are running a gated check-in build or manually building a shelveset, you cannot use this variable in your build number format.
     /// </summary>
-    public string SourceBranch => GetReference("SourceBranch");
+    public VariableReference SourceBranch => GetReference("SourceBranch");
 
     /// <summary>
     /// The name of the branch in the triggering repo the build was queued for.
@@ -315,7 +315,7 @@ public sealed class BuildVariableReference : VariableReferenceBase
     ///
     /// Note: In TFVC, if you are running a gated check-in build or manually building a shelveset, you cannot use this variable in your build number format. 	Yes
     /// </summary>
-    public string SourceBranchName => GetReference("SourceBranchName");
+    public VariableReference SourceBranchName => GetReference("SourceBranchName");
 
     /// <summary>
     /// The local path on the agent where your source code files are downloaded. For example: c:\agent_work\1\s
@@ -325,14 +325,14 @@ public sealed class BuildVariableReference : VariableReferenceBase
     ///
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// </summary>
-    public string SourcesDirectory => GetReference("SourcesDirectory");
+    public VariableReference SourcesDirectory => GetReference("SourcesDirectory");
 
     /// <summary>
     /// The latest version control change of the triggering repo that is included in this build.
     ///   - Git: The commit ID
     ///   - TFVC: the changeset
     /// </summary>
-    public string SourceVersion => GetReference("SourceVersion");
+    public VariableReference SourceVersion => GetReference("SourceVersion");
 
     /// <summary>
     /// The comment of the commit or changeset for the triggering repo. We truncate the message to the first line or 200 characters, whichever is shorter.
@@ -340,14 +340,14 @@ public sealed class BuildVariableReference : VariableReferenceBase
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag. Also, this variable is only available on the step level and is neither available in the job nor stage levels (i.e. the message is not extracted until the job had started and checked out the code).
     /// Note: This variable is available in TFS 2015.4.
     /// </summary>
-    public string SourceVersionMessage => GetReference("SourceVersionMessage");
+    public VariableReference SourceVersionMessage => GetReference("SourceVersionMessage");
 
     /// <summary>
     /// Defined if your repository is Team Foundation Version Control.
     /// If you are running a gated build or a shelveset build, this is set to the name of the shelveset you are building.
     /// Note: This variable yields a value that is invalid for build use in a build number format.
     /// </summary>
-    public string SourceTfvcShelveset => GetReference("SourceTfvcShelveset");
+    public VariableReference SourceTfvcShelveset => GetReference("SourceTfvcShelveset");
 
     /// <summary>
     /// The local path on the agent where the test results are created.
@@ -355,7 +355,7 @@ public sealed class BuildVariableReference : VariableReferenceBase
     ///
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// </summary>
-    public string CommonTestResultsDirectory => GetReference("Common.TestResultsDirectory");
+    public VariableReference CommonTestResultsDirectory => GetReference("Common.TestResultsDirectory");
 
     /// <summary>
     /// Variables connected to why the build was created.
@@ -376,7 +376,7 @@ public sealed class RepositoryVariableReference : VariableReferenceBase
     ///
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// </summary>
-    public string Clean => GetReference("Clean");
+    public VariableReference Clean => GetReference("Clean");
 
     /// <summary>
     /// The local path on the agent where your source code files are downloaded.
@@ -389,7 +389,7 @@ public sealed class RepositoryVariableReference : VariableReferenceBase
     ///
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// </summary>
-    public string LocalPath => GetReference("LocalPath");
+    public VariableReference LocalPath => GetReference("LocalPath");
 
     /// <summary>
     /// The unique identifier of the repository.
@@ -397,14 +397,14 @@ public sealed class RepositoryVariableReference : VariableReferenceBase
     ///
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// </summary>
-    public string ID => GetReference("ID");
+    public VariableReference ID => GetReference("ID");
 
     /// <summary>
     /// The name of the triggering repository.
     ///
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// </summary>
-    public string Name => GetReference("Name");
+    public VariableReference Name => GetReference("Name");
 
     /// <summary>
     /// The type of the triggering repository.
@@ -416,7 +416,7 @@ public sealed class RepositoryVariableReference : VariableReferenceBase
     ///
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// </summary>
-    public string Provider => GetReference("Provider");
+    public VariableReference Provider => GetReference("Provider");
 
     /// <summary>
     /// Defined if your repository is Team Foundation Version Control. The name of the TFVC workspace used by the build agent.
@@ -424,7 +424,7 @@ public sealed class RepositoryVariableReference : VariableReferenceBase
     ///
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// </summary>
-    public string TfvcWorkspace => GetReference("Tfvc.Workspace");
+    public VariableReference TfvcWorkspace => GetReference("Tfvc.Workspace");
 
     /// <summary>
     /// The URL for the triggering repository. For example:
@@ -433,14 +433,14 @@ public sealed class RepositoryVariableReference : VariableReferenceBase
     ///
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// </summary>
-    public string Uri => GetReference("Uri");
+    public VariableReference Uri => GetReference("Uri");
 
     /// <summary>
     /// The value you've selected for Checkout submodules on the repository tab. With multiple repos checked out, this value tracks the triggering repository's setting.
     ///
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// </summary>
-    public string GitSubmoduleCheckout => GetReference("Git.SubmoduleCheckout");
+    public VariableReference GitSubmoduleCheckout => GetReference("Git.SubmoduleCheckout");
 }
 
 public sealed class TriggeredByVariableReference : VariableReferenceBase
@@ -457,7 +457,7 @@ public sealed class TriggeredByVariableReference : VariableReferenceBase
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// If you are triggering a YAML pipeline using resources, you should use the resources variables instead.
     /// </summary>
-    public string BuildId => GetReference("BuildId");
+    public VariableReference BuildId => GetReference("BuildId");
 
     /// <summary>
     /// If the build was triggered by another build, then this variable is set to the DefinitionID of the triggering build. In Classic pipelines, this variable is triggered by a build completion trigger.
@@ -465,7 +465,7 @@ public sealed class TriggeredByVariableReference : VariableReferenceBase
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// If you are triggering a YAML pipeline using resources, you should use the resources variables instead.
     /// </summary>
-    public string DefinitionId => GetReference("DefinitionId");
+    public VariableReference DefinitionId => GetReference("DefinitionId");
 
     /// <summary>
     /// If the build was triggered by another build, then this variable is set to the name of the triggering build pipeline. In Classic pipelines, this variable is triggered by a build completion trigger.
@@ -473,7 +473,7 @@ public sealed class TriggeredByVariableReference : VariableReferenceBase
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// If you are triggering a YAML pipeline using resources, you should use the resources variables instead.
     /// </summary>
-    public string DefinitionName => GetReference("DefinitionName");
+    public VariableReference DefinitionName => GetReference("DefinitionName");
 
     /// <summary>
     /// If the build was triggered by another build, then this variable is set to the number of the triggering build. In Classic pipelines, this variable is triggered by a build completion trigger.
@@ -481,7 +481,7 @@ public sealed class TriggeredByVariableReference : VariableReferenceBase
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// If you are triggering a YAML pipeline using resources, you should use the resources variables instead.
     /// </summary>
-    public string BuildNumber => GetReference("BuildNumber");
+    public VariableReference BuildNumber => GetReference("BuildNumber");
 
     /// <summary>
     /// If the build was triggered by another build, then this variable is set to ID of the project that contains the triggering build. In Classic pipelines, this variable is triggered by a build completion trigger.
@@ -489,7 +489,7 @@ public sealed class TriggeredByVariableReference : VariableReferenceBase
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// If you are triggering a YAML pipeline using resources, you should use the resources variables instead.
     /// </summary>
-    public string ProjectID => GetReference("ProjectID");
+    public VariableReference ProjectID => GetReference("ProjectID");
 }
 
 public sealed class SystemVariableReference : VariableReferenceBase
@@ -511,23 +511,23 @@ public sealed class SystemVariableReference : VariableReferenceBase
     /// Use System.AccessToken from YAML scripts.
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// </summary>
-    public string AccessToken => GetReference("AccessToken");
+    public VariableReference AccessToken => GetReference("AccessToken");
 
     /// <summary>
     /// Variable that can be set for a pipeline run manually (either true or false).
     /// </summary>
-    public string Debug => GetReference("Debug");
+    public VariableReference Debug => GetReference("Debug");
 
     /// <summary>
     /// The GUID of the TFS collection or Azure DevOps organization.
     /// </summary>
-    public string CollectionId => GetReference("CollectionId");
+    public VariableReference CollectionId => GetReference("CollectionId");
 
     /// <summary>
     /// The URI of the TFS collection or Azure DevOps organization.
     /// For example: https://dev.azure.com/fabrikamfiber/.
     /// </summary>
-    public string CollectionUri => GetReference("CollectionUri");
+    public VariableReference CollectionUri => GetReference("CollectionUri");
 
     /// <summary>
     /// The local path on the agent where your source code files are downloaded.
@@ -536,37 +536,37 @@ public sealed class SystemVariableReference : VariableReferenceBase
     /// You can modify how files are downloaded on the Repository tab.
     /// This variable is agent-scoped. It can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// </summary>
-    public string DefaultWorkingDirectory => GetReference("DefaultWorkingDirectory");
+    public VariableReference DefaultWorkingDirectory => GetReference("DefaultWorkingDirectory");
 
     /// <summary>
     /// The ID of the build pipeline.
     /// </summary>
-    public string DefinitionId => GetReference("DefinitionId");
+    public VariableReference DefinitionId => GetReference("DefinitionId");
 
     /// <summary>
     /// Set to build if the pipeline is a build. For a release, the values are deployment for a Deployment group job, gates during evaluation of gates, and release for other (Agent and Agentless) jobs.
     /// </summary>
-    public string HostType => GetReference("HostType");
+    public VariableReference HostType => GetReference("HostType");
 
     /// <summary>
     /// Set to 1 the first time this job is attempted, and increments every time the job is retried.
     /// </summary>
-    public string JobAttempt => GetReference("JobAttempt");
+    public VariableReference JobAttempt => GetReference("JobAttempt");
 
     /// <summary>
     /// The human-readable name given to a job.
     /// </summary>
-    public string JobDisplayName => GetReference("JobDisplayName");
+    public VariableReference JobDisplayName => GetReference("JobDisplayName");
 
     /// <summary>
     /// A unique identifier for a single attempt of a single job. The value is unique to the current pipeline.
     /// </summary>
-    public string JobId => GetReference("JobId");
+    public VariableReference JobId => GetReference("JobId");
 
     /// <summary>
     /// The name of the job, typically used for expressing dependencies and accessing output variables.
     /// </summary>
-    public string JobName => GetReference("JobName");
+    public VariableReference JobName => GetReference("JobName");
 
     /// <summary>
     /// Set to 1 the first time this phase is attempted, and increments every time the job is retried.
@@ -574,49 +574,49 @@ public sealed class SystemVariableReference : VariableReferenceBase
     /// We've mostly removed the concept of "phase" from Azure Pipelines. Matrix and multi-config jobs are the only place where "phase" is still distinct from "job".
     /// One phase can instantiate multiple jobs which differ only in their inputs.
     /// </summary>
-    public string PhaseAttempt => GetReference("PhaseAttempt");
+    public VariableReference PhaseAttempt => GetReference("PhaseAttempt");
 
     /// <summary>
     /// The human-readable name given to a phase.
     /// </summary>
-    public string PhaseDisplayName => GetReference("PhaseDisplayName");
+    public VariableReference PhaseDisplayName => GetReference("PhaseDisplayName");
 
     /// <summary>
     /// A string-based identifier for a job, typically used for expressing dependencies and accessing output variables.
     /// </summary>
-    public string PhaseName => GetReference("PhaseName");
+    public VariableReference PhaseName => GetReference("PhaseName");
 
     /// <summary>
     /// Set to 1 the first time this stage is attempted, and increments every time the job is retried.
     /// </summary>
-    public string StageAttempt => GetReference("StageAttempt");
+    public VariableReference StageAttempt => GetReference("StageAttempt");
 
     /// <summary>
     /// The human-readable name given to a stage.
     /// </summary>
-    public string StageDisplayName => GetReference("StageDisplayName");
+    public VariableReference StageDisplayName => GetReference("StageDisplayName");
 
     /// <summary>
     /// A string-based identifier for a stage, typically used for expressing dependencies and accessing output variables.
     /// </summary>
-    public string StageName => GetReference("StageName");
+    public VariableReference StageName => GetReference("StageName");
 
     /// <summary>
     /// The URI of the TFS collection or Azure DevOps organization.
     /// For example: https://dev.azure.com/fabrikamfiber/.
     /// This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.
     /// </summary>
-    public string TeamFoundationCollectionUri => GetReference("TeamFoundationCollectionUri");
+    public VariableReference TeamFoundationCollectionUri => GetReference("TeamFoundationCollectionUri");
 
     /// <summary>
     /// The name of the project that contains this build.
     /// </summary>
-    public string TeamProject => GetReference("TeamProject");
+    public VariableReference TeamProject => GetReference("TeamProject");
 
     /// <summary>
     /// The ID of the project that this build belongs to.
     /// </summary>
-    public string TeamProjectId => GetReference("TeamProjectId");
+    public VariableReference TeamProjectId => GetReference("TeamProjectId");
 }
 
 public sealed class PullRequestVariableReference : VariableReferenceBase
@@ -630,21 +630,21 @@ public sealed class PullRequestVariableReference : VariableReferenceBase
     /// <summary>
     /// If the pull request is from a fork of the repository, this variable is set to True. Otherwise, it is set to False.
     /// </summary>
-    public string IsFork => GetReference("IsFork");
+    public VariableReference IsFork => GetReference("IsFork");
 
     /// <summary>
     /// The ID of the pull request that caused this build.
     /// For example: 17.
     /// (This variable is initialized only if the build ran because of a Git PR affected by a branch policy).
     /// </summary>
-    public string PullRequestId => GetReference("PullRequestId");
+    public VariableReference PullRequestId => GetReference("PullRequestId");
 
     /// <summary>
     /// The number of the pull request that caused this build.
     /// This variable is populated for pull requests from GitHub which have a different pull request ID and pull request number.
     /// This variable is only available in a YAML pipeline if the PR is a affected by a branch policy.
     /// </summary>
-    public string PullRequestNumber => GetReference("PullRequestNumber");
+    public VariableReference PullRequestNumber => GetReference("PullRequestNumber");
 
     /// <summary>
     /// The branch that is being reviewed in a pull request.
@@ -652,13 +652,13 @@ public sealed class PullRequestVariableReference : VariableReferenceBase
     /// (This variable is initialized only if the build ran because of a Git PR affected by a branch policy).
     /// This variable is only available in a YAML pipeline if the PR is affected by a branch policy.
     /// </summary>
-    public string SourceBranch => GetReference("SourceBranch");
+    public VariableReference SourceBranch => GetReference("SourceBranch");
 
     /// <summary>
     /// The URL to the repo that contains the pull request.
     /// For example: https://dev.azure.com/ouraccount/_git/OurProject.
     /// </summary>
-    public string SourceRepositoryURI => GetReference("SourceRepositoryURI");
+    public VariableReference SourceRepositoryURI => GetReference("SourceRepositoryURI");
 
     /// <summary>
     /// The branch that is the target of a pull request.
@@ -666,7 +666,7 @@ public sealed class PullRequestVariableReference : VariableReferenceBase
     /// This variable is initialized only if the build ran because of a Git PR affected by a branch policy.
     /// This variable is only available in a YAML pipeline if the PR is affected by a branch policy.
     /// </summary>
-    public string TargetBranch => GetReference("TargetBranch");
+    public VariableReference TargetBranch => GetReference("TargetBranch");
 }
 
 public sealed class PipelineVariableReference : VariableReferenceBase
@@ -681,7 +681,7 @@ public sealed class PipelineVariableReference : VariableReferenceBase
     /// Workspace directory for a particular pipeline. This variable has the same value as Agent.BuildDirectory.
     /// For example: /home/vsts/work/1
     /// </summary>
-    public string Workspace => GetReference("Workspace");
+    public VariableReference Workspace => GetReference("Workspace");
 }
 
 public sealed class EnvironmentVariableReference : VariableReferenceBase
@@ -696,25 +696,25 @@ public sealed class EnvironmentVariableReference : VariableReferenceBase
     /// Name of the environment targeted in the deployment job to run the deployment steps and record the deployment history.
     /// For example: smarthotel-dev
     /// </summary>
-    public string Name => GetReference("Name");
+    public VariableReference Name => GetReference("Name");
 
     /// <summary>
     /// ID of the environment targeted in the deployment job.
     /// For example: 10
     /// </summary>
-    public string Id => GetReference("Id");
+    public VariableReference Id => GetReference("Id");
 
     /// <summary>
     /// Name of the specific resource within the environment targeted in the deployment job to run the deployment steps and record the deployment history.
     /// For example, bookings which is a Kubernetes namespace that has been added as a resource to the environment smarthotel-dev.
     /// </summary>
-    public string ResourceName => GetReference("ResourceName");
+    public VariableReference ResourceName => GetReference("ResourceName");
 
     /// <summary>
     /// ID of the specific resource within the environment targeted in the deployment job to run the deployment steps.
     /// For example: 4
     /// </summary>
-    public string ResourceId => GetReference("ResourceId");
+    public VariableReference ResourceId => GetReference("ResourceId");
 }
 
 public sealed class StrategyVariableReference : VariableReferenceBase
@@ -728,12 +728,12 @@ public sealed class StrategyVariableReference : VariableReferenceBase
     /// <summary>
     /// The name of the deployment strategy: canary, runOnce, or rolling.
     /// </summary>
-    public string Name => GetReference("Name");
+    public VariableReference Name => GetReference("Name");
 
     /// <summary>
     /// The current cycle name in a deployment: PreIteration, Iteration, or PostIteration.
     /// </summary>
-    public string CycleName => GetReference("CycleName");
+    public VariableReference CycleName => GetReference("CycleName");
 }
 
 public sealed class ChecksVariableReference : VariableReferenceBase
@@ -748,5 +748,5 @@ public sealed class ChecksVariableReference : VariableReferenceBase
     /// Set to 1 the first time this stage is attempted, and increments every time the stage is retried.
     /// This variable can only be used within an approval or check for an environment.For example, you could use $(Checks.StageAttempt) within an Invoke REST API check.
     /// </summary>
-    public string StageAttempt => GetReference("StageAttempt");
+    public VariableReference StageAttempt => GetReference("StageAttempt");
 }

--- a/tests/Sharpliner.Tests/AzureDevOps/ConditionedExpressions/ConditionalsTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/ConditionedExpressions/ConditionalsTests.cs
@@ -31,8 +31,8 @@ public class ConditionalsTests
         variable.Condition!.ToString().Should().Be(
             "and(" +
                 "notIn('bar', 'foo', 'xyz', 'foo'), " +
-                "ne('$(Configuration)', 'Debug'), " +
-                "containsValue('$(System.JobId)', 10))");
+                "ne(variables['Configuration'], 'Debug'), " +
+                "containsValue(variables['System.JobId'], 10))");
     }
 
     private class Or_Condition_Test_Pipeline : TestPipeline
@@ -62,9 +62,9 @@ public class ConditionalsTests
             "or(" +
                 "and(" +
                     "lt(5, 3), " +
-                    "eq('$(Build.SourceBranch)', 'refs/heads/production'), " +
+                    "eq(variables['Build.SourceBranch'], 'refs/heads/production'), " +
                     "eq(variables['Build.SourceBranch'], 'refs/heads/release')), " +
-                "ne('$(Configuration)', 'Debug'), " +
+                "ne(variables['Configuration'], 'Debug'), " +
                 "eq(variables['Build.Reason'], 'PullRequest'))");
     }
 
@@ -295,7 +295,7 @@ public class ConditionalsTests
         var variable1 = pipeline.Pipeline.Variables.ElementAt(0);
         var variable2 = pipeline.Pipeline.Variables.ElementAt(1);
 
-        variable1.Condition!.ToString().Should().Be("contains('$(Build.SourceBranch)', 'refs/heads/feature/')");
+        variable1.Condition!.ToString().Should().Be("contains(variables['Build.SourceBranch'], 'refs/heads/feature/')");
         variable2.Condition!.ToString().Should().Be("contains(variables['Build.SourceBranch'], 'refs/heads/feature/')");
     }
 
@@ -322,7 +322,7 @@ public class ConditionalsTests
         var variable1 = pipeline.Pipeline.Variables.ElementAt(0);
         var variable2 = pipeline.Pipeline.Variables.ElementAt(1);
 
-        variable1.Condition!.ToString().Should().Be("startsWith('$(Build.SourceBranch)', 'refs/heads/feature/')");
+        variable1.Condition!.ToString().Should().Be("startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/')");
         variable2.Condition!.ToString().Should().Be("startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/')");
     }
 
@@ -349,7 +349,7 @@ public class ConditionalsTests
         var variable1 = pipeline.Pipeline.Variables.ElementAt(0);
         var variable2 = pipeline.Pipeline.Variables.ElementAt(1);
 
-        variable1.Condition!.ToString().Should().Be("endsWith('$(Build.SourceBranch)', 'refs/heads/feature/')");
+        variable1.Condition!.ToString().Should().Be("endsWith(variables['Build.SourceBranch'], 'refs/heads/feature/')");
         variable2.Condition!.ToString().Should().Be("endsWith(variables['Build.SourceBranch'], 'refs/heads/feature/')");
     }
 }

--- a/tests/Sharpliner.Tests/AzureDevOps/Model/VariableSerializationTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/Model/VariableSerializationTests.cs
@@ -99,7 +99,7 @@ public class VariableSerializationTests
         yaml.Trim().Should().Be(
             """
             variables:
-            - ${{ if containsValue('refs/heads/feature/', parameters.allowedTags, variables['foo'], '$(Build.Reason)', '$(Build.SourceBranch)') }}:
+            - ${{ if containsValue('refs/heads/feature/', parameters.allowedTags, variables['foo'], variables['Build.Reason'], variables['Build.SourceBranch']) }}:
               - name: feature
                 value: on
             """
@@ -128,7 +128,7 @@ public class VariableSerializationTests
         yaml.Trim().Should().Be(
             """
             variables:
-            - ${{ if gt('$(Build.BuildNumber)', 100) }}:
+            - ${{ if gt(variables['Build.BuildNumber'], 100) }}:
               - name: high
                 value: true
             """


### PR DESCRIPTION
Change built-in variables to strong-typed objects to benefit from the new Macro / Runtime syntaxes