### PR TITLE
Allow variable/parameter expressions everywhere

### DIFF
--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/Conditioned.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/Conditioned.cs
@@ -9,6 +9,21 @@ namespace Sharpliner.AzureDevOps.ConditionedExpressions;
 
 public abstract record Conditioned : IYamlConvertible
 {
+    private class ValueEqualityList : List<Conditioned>
+    {
+        public override bool Equals(object? obj)
+        {
+            if (obj is ValueEqualityList other && Count == 0 && other.Count == 0)
+            {
+                return true;
+            }
+
+            return base.Equals(obj);
+        }
+
+        public override int GetHashCode() => base.GetHashCode();
+    }
+
     /// <summary>
     /// Evaluated textual representation of the condition, e.g. "ne('foo', 'bar')".
     /// </summary>
@@ -22,7 +37,7 @@ public abstract record Conditioned : IYamlConvertible
     /// <summary>
     /// In case we define multiple items inside one ${{ if }}, they are stored here.
     /// </summary>
-    internal List<Conditioned> Definitions { get; } = new();
+    internal List<Conditioned> Definitions { get; } = new ValueEqualityList();
 
     /// <summary>
     /// When serializing, we need to distinguish whether serializing a list of items under a condition or just a value.

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/ParameterReference.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/ParameterReference.cs
@@ -32,6 +32,20 @@ public class ParameterReference : IRuntimeExpression, ICompileTimeExpression, IY
     public void Write(IEmitter emitter, ObjectSerializer nestedObjectSerializer)
         => emitter.Emit(new Scalar(ToString()));
 
+    public static implicit operator Conditioned<int>(ParameterReference value) => new ConditionedParameterReference<int>(value);
+
+    public static implicit operator Conditioned<bool>(ParameterReference value) => new ConditionedParameterReference<bool>(value);
+
+    public static implicit operator Conditioned<string>(ParameterReference value) => new ConditionedParameterReference<string>(value);
+
+    public static implicit operator Conditioned<TimeSpan>(ParameterReference value) => new ConditionedParameterReference<TimeSpan>(value);
+
+    public static implicit operator Conditioned<TemplateParameters>(ParameterReference value) => new ConditionedParameterReference<TemplateParameters>(value);
+
+    public static implicit operator Conditioned<ConditionedDictionary>(ParameterReference value) => new ConditionedParameterReference<ConditionedDictionary>(value);
+
+    public static implicit operator Conditioned<InlineCondition>(ParameterReference value) => new ConditionedParameterReference<InlineCondition>(value);
+
     public static implicit operator Conditioned<VariableBase>(ParameterReference value) => new ConditionedParameterReference<VariableBase>(value);
 
     public static implicit operator Conditioned<Stage>(ParameterReference value) => new ConditionedParameterReference<Stage>(value);
@@ -41,6 +55,18 @@ public class ParameterReference : IRuntimeExpression, ICompileTimeExpression, IY
     public static implicit operator Conditioned<Step>(ParameterReference value) => new ConditionedParameterReference<Step>(value);
 
     public static implicit operator Conditioned<Pool>(ParameterReference value) => new ConditionedParameterReference<Pool>(value);
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is ParameterReference other)
+        {
+            return ParameterName == other.ParameterName;
+        }
+
+        return false;
+    }
+
+    public override int GetHashCode() => ParameterName.GetHashCode();
 }
 
 public record ConditionedParameterReference<T> : Conditioned<T>

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/VariableReference.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/VariableReference.cs
@@ -30,4 +30,53 @@ public class VariableReference : IRuntimeExpression, IMacroExpression, ICompileT
 
     public void Write(IEmitter emitter, ObjectSerializer nestedObjectSerializer)
         => emitter.Emit(new Scalar(ToString()));
+
+    public static implicit operator Conditioned<int>(VariableReference value) => new ConditionedVariableReference<int>(value);
+
+    public static implicit operator Conditioned<bool>(VariableReference value) => new ConditionedVariableReference<bool>(value);
+
+    public static implicit operator Conditioned<string>(VariableReference value) => new ConditionedVariableReference<string>(value);
+
+    public static implicit operator Conditioned<TimeSpan>(VariableReference value) => new ConditionedVariableReference<TimeSpan>(value);
+
+    public static implicit operator Conditioned<TemplateParameters>(VariableReference value) => new ConditionedVariableReference<TemplateParameters>(value);
+
+    public static implicit operator Conditioned<ConditionedDictionary>(VariableReference value) => new ConditionedVariableReference<ConditionedDictionary>(value);
+
+    public static implicit operator Conditioned<InlineCondition>(VariableReference value) => new ConditionedVariableReference<InlineCondition>(value);
+
+    public static implicit operator Conditioned<VariableBase>(VariableReference value) => new ConditionedVariableReference<VariableBase>(value);
+
+    public static implicit operator Conditioned<Stage>(VariableReference value) => new ConditionedVariableReference<Stage>(value);
+
+    public static implicit operator Conditioned<JobBase>(VariableReference value) => new ConditionedVariableReference<JobBase>(value);
+
+    public static implicit operator Conditioned<Step>(VariableReference value) => new ConditionedVariableReference<Step>(value);
+
+    public static implicit operator Conditioned<Pool>(VariableReference value) => new ConditionedVariableReference<Pool>(value);
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is VariableReference other)
+        {
+            return VariableName == other.VariableName;
+        }
+
+        return false;
+    }
+
+    public override int GetHashCode() => VariableName.GetHashCode();
+}
+
+public record ConditionedVariableReference<T> : Conditioned<T>
+{
+    private readonly VariableReference _variable;
+
+    public ConditionedVariableReference(VariableReference variable) : base()
+    {
+        _variable = variable;
+    }
+
+    public override void Write(IEmitter emitter, ObjectSerializer nestedObjectSerializer)
+        => emitter.Emit(new Scalar(_variable.CompileTimeExpression));
 }

--- a/src/Sharpliner/AzureDevOps/Model/BuildResource.cs
+++ b/src/Sharpliner/AzureDevOps/Model/BuildResource.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using Sharpliner.AzureDevOps.ConditionedExpressions;
 using YamlDotNet.Serialization;
 
 namespace Sharpliner.AzureDevOps;
@@ -20,25 +21,25 @@ public record BuildResource
     /// The type of your build service like Jenkins, circleCI etc.
     /// </summary>
     [DisallowNull]
-    public string? Type { get; init; }
+    public Conditioned<string>? Type { get; init; }
 
     /// <summary>
     /// Service connection for your build service
     /// </summary>
     [DisallowNull]
-    public string? Connection { get; init; }
+    public Conditioned<string>? Connection { get; init; }
 
     /// <summary>
     /// Source definition of the build
     /// </summary>
     [DisallowNull]
-    public string? Source { get; init; }
+    public Conditioned<string>? Source { get; init; }
 
     /// <summary>
     /// The build number to pick the artifact, defaults to latest successful build
     /// </summary>
     [DisallowNull]
-    public string? Version { get; init; }
+    public Conditioned<string>? Version { get; init; }
 
     /// <summary>
     /// Triggers aren't enabled by default and should be explicitly set

--- a/src/Sharpliner/AzureDevOps/Model/ContainerReference.cs
+++ b/src/Sharpliner/AzureDevOps/Model/ContainerReference.cs
@@ -13,13 +13,13 @@ public record ContainerReference
     /// Container image name
     /// </summary>
     [DisallowNull]
-    public string? Image { get; init; }
+    public Conditioned<string>? Image { get; init; }
 
     /// <summary>
     /// Arguments to pass to container at startup
     /// </summary>
     [DisallowNull]
-    public string? Options { get; init; }
+    public Conditioned<string>? Options { get; init; }
 
     /// <summary>
     /// Endpoint for a private container registry

--- a/src/Sharpliner/AzureDevOps/Model/ContainerResource.cs
+++ b/src/Sharpliner/AzureDevOps/Model/ContainerResource.cs
@@ -22,19 +22,19 @@ public record ContainerResource
     /// Container image name
     /// </summary>
     [DisallowNull]
-    public string? Image { get; init; }
+    public Conditioned<string>? Image { get; init; }
 
     /// <summary>
     /// Arguments to pass to container at startup
     /// </summary>
     [DisallowNull]
-    public string? Options { get; init; }
+    public Conditioned<string>? Options { get; init; }
 
     /// <summary>
     /// Reference to a service connection for the private registry
     /// </summary>
     [DisallowNull]
-    public string? Endpoint { get; init; }
+    public Conditioned<string>? Endpoint { get; init; }
 
     /// <summary>
     /// A map of environment variables that are available to all steps of the jobs. When more than one variable

--- a/src/Sharpliner/AzureDevOps/Model/JobBase.cs
+++ b/src/Sharpliner/AzureDevOps/Model/JobBase.cs
@@ -20,7 +20,7 @@ public abstract record JobBase : IDependsOn
     /// </summary>
     [YamlMember(Order = 100)]
     [DisallowNull]
-    public string? DisplayName { get; init; }
+    public Conditioned<string>? DisplayName { get; init; }
 
     /// <summary>
     /// List of names of other jobs this job depends on
@@ -54,20 +54,20 @@ public abstract record JobBase : IDependsOn
     /// </summary>
     [YamlIgnore]
     [DisallowNull]
-    public TimeSpan? Timeout { get; init; }
+    public Conditioned<TimeSpan>? Timeout { get; init; }
 
     [YamlMember(Order = 800)]
-    public int? TimeoutInMinutes => Timeout != null ? (int)Timeout.Value.TotalMinutes : null;
+    public Conditioned<int>? TimeoutInMinutes => Timeout?.Definition != null ? (int)Timeout.Definition.TotalMinutes : null;
 
     /// <summary>
     /// How much time to give 'run always even if cancelled tasks' before killing them
     /// </summary>
     [YamlIgnore]
     [DisallowNull]
-    public TimeSpan? CancelTimeout { get; init; }
+    public Conditioned<TimeSpan>? CancelTimeout { get; init; }
 
     [YamlMember(Order = 900)]
-    public int? CancelTimeoutInMinutes => CancelTimeout != null ? (int)CancelTimeout.Value.TotalMinutes : null;
+    public Conditioned<int>? CancelTimeoutInMinutes => CancelTimeout?.Definition != null ? (int)CancelTimeout.Definition.TotalMinutes : null;
 
     /// <summary>
     /// What to clean up before the job runs
@@ -84,14 +84,14 @@ public abstract record JobBase : IDependsOn
 
     [YamlMember(Order = 1100)]
     [DisallowNull]
-    public InlineCondition? Condition { get; init; }
+    public Conditioned<InlineCondition>? Condition { get; init; }
 
     /// <summary>
     /// 'true' if future jobs should run even if this job fails
     /// defaults to 'false'
     /// </summary>
     [YamlMember(Order = 1200)]
-    public bool ContinueOnError { get; init; } = false;
+    public Conditioned<bool>? ContinueOnError { get; init; }
 
     protected JobBase(string name, string? displayName = null)
     {

--- a/src/Sharpliner/AzureDevOps/Model/PackageResource.cs
+++ b/src/Sharpliner/AzureDevOps/Model/PackageResource.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using Sharpliner.AzureDevOps.ConditionedExpressions;
 using YamlDotNet.Serialization;
 
 namespace Sharpliner.AzureDevOps;
@@ -24,7 +25,7 @@ public abstract record PackageResource
     /// Github service connection with the PAT type
     /// </summary>
     [DisallowNull]
-    public string? Connection { get; init; }
+    public Conditioned<string>? Connection { get; init; }
 
     /// <summary>
     /// &lt;Repository&gt;/&lt;Name of the package&gt;

--- a/src/Sharpliner/AzureDevOps/Model/Pool.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Pool.cs
@@ -16,31 +16,34 @@ public record Pool
     /// Identifier for this step (A-Z, a-z, 0-9, and underscore).
     /// </summary>
     [YamlMember(Order = 100)]
-    public string? Name { get; init; }
+    public Conditioned<string>? Name { get; init; }
 
     public Pool(string? name)
     {
-        Name = name;
+        if (name is not null)
+        {
+            Name = name;
+        }
     }
 
-    public static implicit operator Pool(string vmImage)
-    {
-        return new HostedPool(vmImage: vmImage);
-    }
+    public static implicit operator Pool(string vmImage) => new HostedPool(vmImage: vmImage);
 }
 
 public record HostedPool : Pool
 {
     public HostedPool(string? name = null, string? vmImage = null) : base(name)
     {
-        VmImage = vmImage;
+        if (vmImage is not null)
+        {
+            VmImage = vmImage;
+        }
     }
 
     /// <summary>
     /// Identifier for this step (A-Z, a-z, 0-9, and underscore).
     /// </summary>
     [YamlMember(Order = 105)]
-    public string? VmImage { get; init; }
+    public Conditioned<string>? VmImage { get; init; }
 
     [YamlMember(Order = 110)]
     [DisallowNull]
@@ -53,7 +56,7 @@ public record HostedPool : Pool
 /// </summary>
 public record ServerPool : Pool, IYamlConvertible
 {
-    public ServerPool() : base((string?)null)
+    public ServerPool() : base(null)
     {
     }
 

--- a/src/Sharpliner/AzureDevOps/Model/RepositoryResource.cs
+++ b/src/Sharpliner/AzureDevOps/Model/RepositoryResource.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using Sharpliner.AzureDevOps.ConditionedExpressions;
 using YamlDotNet.Serialization;
 
 namespace Sharpliner.AzureDevOps;
@@ -26,14 +27,14 @@ public record RepositoryResource
     /// Repository name (format depends on `Type`)
     /// </summary>
     [DisallowNull]
-    public string? Name { get; init; }
+    public Conditioned<string>? Name { get; init; }
 
     /// <summary>
     /// Ref name to use
     /// Defaults to 'refs/heads/main'
     /// </summary>
     [DisallowNull]
-    public string? Ref { get; init; }
+    public Conditioned<string>? Ref { get; init; }
 
     /// <summary>
     /// Name of the service connection to use (for types that aren't Azure Repos)

--- a/src/Sharpliner/AzureDevOps/Model/ScheduledTrigger.cs
+++ b/src/Sharpliner/AzureDevOps/Model/ScheduledTrigger.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Sharpliner.AzureDevOps.ConditionedExpressions;
 using YamlDotNet.Serialization;
 
 namespace Sharpliner.AzureDevOps;
@@ -16,14 +17,14 @@ public record ScheduledTrigger
     /// </summary>
     [YamlMember(Order = 1, Alias = "cron")]
     [DisallowNull]
-    public string? CronSchedule { get; init; }
+    public Conditioned<string>? CronSchedule { get; init; }
 
     /// <summary>
     /// Friendly name given to a specific schedule
     /// </summary>
     [YamlMember(Order = 100)]
     [DisallowNull]
-    public string? DisplayName { get; init; }
+    public Conditioned<string>? DisplayName { get; init; }
 
     [DisallowNull]
     [YamlMember(Order = 200)]
@@ -34,7 +35,7 @@ public record ScheduledTrigger
     /// Defaults to false
     /// </summary>
     [YamlMember(Order = 300)]
-    public bool Always { get; init; } = false;
+    public Conditioned<bool>? Always { get; init; }
 
     public ScheduledTrigger(string cronSchedule, params string[] branches)
     {

--- a/src/Sharpliner/AzureDevOps/Model/Step.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Step.cs
@@ -14,26 +14,30 @@ namespace Sharpliner.AzureDevOps;
 /// </summary>
 public abstract record Step
 {
-    private string? _name;
+    private Conditioned<string>? _name;
 
     /// <summary>
     /// Friendly name displayed in the UI.
     /// </summary>
     [YamlMember(Order = 100)]
     [DisallowNull]
-    public string? DisplayName { get; init; }
+    public Conditioned<string>? DisplayName { get; init; }
 
     /// <summary>
     /// Identifier for this step (A-Z, a-z, 0-9, and underscore).
     /// </summary>
     [YamlMember(Order = 150)]
     [DisallowNull]
-    public string? Name
+    public Conditioned<string>? Name
     {
         get => _name;
         init
         {
-            Pipeline.ValidateName(value);
+            if (value is not ConditionedParameterReference<string> && value.Definition is not null)
+            {
+                Pipeline.ValidateName(value.Definition);
+            }
+
             _name = value;
         }
     }
@@ -50,27 +54,27 @@ public abstract record Step
     /// </summary>
     [YamlMember(Order = 190)]
     [DisallowNull]
-    public InlineCondition? Condition { get; init; }
+    public Conditioned<InlineCondition>? Condition { get; init; }
 
     /// <summary>
     /// Whether future steps should run even if this step fails.
     /// Defaults to 'false'.
     /// </summary>
     [YamlMember(Order = 200)]
-    public bool ContinueOnError { get; init; } = false;
+    public Conditioned<bool>? ContinueOnError { get; init; }
 
     /// <summary>
     /// Timeout after which the step will be stopped.
     /// </summary>
     [YamlIgnore]
     [DisallowNull]
-    public TimeSpan? Timeout { get; init; }
+    public Conditioned<TimeSpan>? Timeout { get; init; }
 
     /// <summary>
     /// Timeout after which the step will be stopped.
     /// </summary>
     [YamlMember(Order = 210)]
-    public int? TimeoutInMinutes => Timeout != null ? (int)Timeout.Value.TotalMinutes : null;
+    public Conditioned<int>? TimeoutInMinutes => Timeout?.Definition != null ? (int)Timeout.Definition.TotalMinutes : null;
 
     /// <summary>
     /// A list of additional items to map into the process's environment.

--- a/src/Sharpliner/AzureDevOps/Model/Strategy.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Strategy.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Sharpliner.AzureDevOps.ConditionedExpressions;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;
@@ -15,7 +16,7 @@ public abstract record Strategy
     /// The maximum number of simultaneous matrix legs to run at once.
     /// If unspecified or set to 0, no limit is applied.
     /// </summary>
-    public int MaxParallel { get; init; } = 0;
+    public Conditioned<int>? MaxParallel { get; init; }
 }
 
 /// <summary>
@@ -54,7 +55,7 @@ public record MatrixStrategy : Strategy, IYamlConvertible
         if (MaxParallel != 0)
         {
             emitter.Emit(new Scalar("maxParallel"));
-            emitter.Emit(new Scalar(MaxParallel.ToString()));
+            emitter.Emit(new Scalar((MaxParallel?.Definition ?? 0).ToString()));
         }
 
         emitter.Emit(new MappingEnd());
@@ -69,5 +70,5 @@ public record ParallelStrategy : Strategy
     /// <summary>
     /// Specifies how many duplicates of a job should run
     /// </summary>
-    public int Parallel { get; init; }
+    public Conditioned<int>? Parallel { get; init; }
 }

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/BashTask.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/BashTask.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using Sharpliner.AzureDevOps.ConditionedExpressions;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 
@@ -15,20 +16,20 @@ public abstract record BashTask : Step
     /// If you leave it empty, the working directory is $(Build.SourcesDirectory).
     /// </summary>
     [YamlMember(Order = 113)]
-    public string? WorkingDirectory { get; init; }
+    public Conditioned<string>? WorkingDirectory { get; init; }
 
     /// <summary>
     /// If this is true, this task will fail if any errors are written to stderr.
     /// Default value: `false`.
     /// </summary>
     [YamlMember(Order = 114)]
-    public bool FailOnStderr { get; init; } = false;
+    public bool? FailOnStderr { get; init; }
 
     /// <summary>
     /// Don't load the system-wide startup file **`/etc/profile`** or any of the personal initialization files.
     /// </summary>
     [YamlMember(Order = 115)]
-    public bool NoProfile { get; init; } = false;
+    public bool? NoProfile { get; init; }
 
     /// <summary>
     /// If this is true, the task will not process `.bashrc` from the user's home directory.
@@ -69,7 +70,7 @@ public record BashFileTask : BashTask, IYamlConvertible
     /// <summary>
     /// Arguments passed to the Bash script.
     /// </summary>
-    public string? Arguments { get; init; }
+    public Conditioned<string>? Arguments { get; init; }
 
     /// <summary>
     /// If the related input is specified, the value will be used as the path of a startup file
@@ -78,7 +79,7 @@ public record BashFileTask : BashTask, IYamlConvertible
     /// If the environment variable BASH_ENV has already been defined, the task will override
     /// this variable only for the current task.
     /// </summary>
-    public string? BashEnv { get; init; }
+    public Conditioned<string>? BashEnv { get; init; }
 
     public BashFileTask(string filePath)
     {
@@ -110,10 +111,10 @@ public record BashFileTask : BashTask, IYamlConvertible
 
         Add("targetType", "filePath", null);
         Add("filePath", FilePath, null);
-        Add("arguments", Arguments, defaultValue.Arguments);
-        Add("workingDirectory", WorkingDirectory, defaultValue.WorkingDirectory);
+        Add("arguments", Arguments, defaultValue.Arguments?.Definition);
+        Add("workingDirectory", WorkingDirectory, defaultValue.WorkingDirectory?.Definition);
         Add("failOnStderr", FailOnStderr, defaultValue.FailOnStderr);
-        Add("bashEnvValue", BashEnv, defaultValue.BashEnv);
+        Add("bashEnvValue", BashEnv, defaultValue.BashEnv?.Definition);
 
         nestedObjectSerializer(new AzureDevOpsTask("Bash@3", this)
         {

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/BashTaskBuilder.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/BashTaskBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using Sharpliner.AzureDevOps.ConditionedExpressions;
 using Sharpliner.Common.Model.Tasks;
 
 namespace Sharpliner.AzureDevOps.Tasks;
@@ -11,7 +12,10 @@ public class BashTaskBuilder : TaskBuilderBase
     /// <param name="resourceFileName">Name of the resource file</param>
     /// <param name="displayName">Display name of the build step</param>
     public InlineBashTask FromResourceFile(string resourceFileName, string? displayName = null!)
-        => new InlineBashTask(GetResourceFile(Assembly.GetCallingAssembly()!, resourceFileName)) with { DisplayName = displayName! };
+        => new InlineBashTask(GetResourceFile(Assembly.GetCallingAssembly()!, resourceFileName)) with
+        {
+            DisplayName = displayName is null ? null! : new Conditioned<string>(displayName),
+        };
 
     /// <summary>
     /// Creates a bash task where the contents come from a file.
@@ -19,14 +23,20 @@ public class BashTaskBuilder : TaskBuilderBase
     /// </summary>
     /// <param name="path">Path to the file</param>
     /// <param name="displayName">Display name of the build step</param>
-    public InlineBashTask FromFile(string path, string? displayName = null!) => new InlineBashTask(System.IO.File.ReadAllText(path)) with { DisplayName = displayName! };
+    public InlineBashTask FromFile(string path, string? displayName = null!) => new InlineBashTask(System.IO.File.ReadAllText(path)) with
+    {
+        DisplayName = displayName is null ? null! : new Conditioned<string>(displayName),
+    };
 
     /// <summary>
     /// Creates a bash task referencing a bash file (contents are not inlined in the YAML).
     /// </summary>
     /// <param name="filePath">Path to the file</param>
     /// <param name="displayName">Name of the build step</param>
-    public BashFileTask File(string filePath, string? displayName = null) => new BashFileTask(filePath) with { DisplayName = displayName! };
+    public BashFileTask File(string filePath, string? displayName = null) => new BashFileTask(filePath)
+    {
+        DisplayName = displayName is null ? null! : new Conditioned<string>(displayName),
+    };
 
     /// <summary>
     /// Creates a bash task with given contents.

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/PowerShellTaskBuilder.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/PowerShellTaskBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using Sharpliner.AzureDevOps.ConditionedExpressions;
 using Sharpliner.Common.Model.Tasks;
 
 namespace Sharpliner.AzureDevOps.Tasks;
@@ -15,7 +16,7 @@ public class PowershellTaskBuilder : TaskBuilderBase
     public InlinePowershellTask FromResourceFile(string resourceFileName, string? displayName = null)
         => new InlinePowershellTask(GetResourceFile(Assembly.GetCallingAssembly()!, resourceFileName)) with
         {
-            DisplayName = displayName!,
+            DisplayName = displayName is null ? null! : new Conditioned<string>(displayName),
             Pwsh = _pwsh
         };
 
@@ -28,7 +29,7 @@ public class PowershellTaskBuilder : TaskBuilderBase
     public InlinePowershellTask FromFile(string path, string? displayName = null)
         => new InlinePowershellTask(System.IO.File.ReadAllText(path)) with
         {
-            DisplayName = displayName!,
+            DisplayName = displayName is null ? null! : new Conditioned<string>(displayName),
             Pwsh = _pwsh
         };
 
@@ -40,7 +41,7 @@ public class PowershellTaskBuilder : TaskBuilderBase
     public PowershellFileTask File(string filePath, string? displayName = null)
         => new PowershellFileTask(filePath) with
         {
-            DisplayName = displayName!,
+            DisplayName = displayName is null ? null! : new Conditioned<string>(displayName),
             Pwsh = _pwsh
         };
 

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/CheckoutTask.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/CheckoutTask.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Sharpliner.AzureDevOps.ConditionedExpressions;
 using YamlDotNet.Serialization;
 
 namespace Sharpliner.AzureDevOps.Tasks;
@@ -16,8 +17,7 @@ public abstract record CheckoutTask : Step
     /// Defaults to false.
     /// </summary>
     [YamlMember(Order = 100)]
-    [DefaultValue(false)]
-    public bool Clean { get; init; } = false;
+    public Conditioned<bool>? Clean { get; init; }
 
     /// <summary>
     /// The depth of commits to ask Git to fetch.
@@ -25,16 +25,14 @@ public abstract record CheckoutTask : Step
     /// Set 0 to no limit (full clone).
     /// </summary>
     [YamlMember(Order = 101)]
-    [DefaultValue(1)]
-    public int FetchDepth { get; init; } = 1;
+    public Conditioned<int>? FetchDepth { get; init; }
 
     /// <summary>
     /// Whether to download Git-LFS files.
     /// Defaults to false.
     /// </summary>
     [YamlMember(Order = 102)]
-    [DefaultValue(false)]
-    public bool Lfs { get; init; } = false;
+    public Conditioned<bool>? Lfs { get; init; }
 
     /// <summary>
     /// Submodules checkout strategy (single level, recursive to get submodules of submodules).
@@ -49,16 +47,14 @@ public abstract record CheckoutTask : Step
     /// Defaults to a directory called `s`.
     /// </summary>
     [YamlMember(Order = 104)]
-    [DefaultValue("s")]
-    public string Path { get; init; } = "s";
+    public Conditioned<string>? Path { get; init; }
 
     /// <summary>
     /// When true, leave the OAuth token in the Git config after the initial fetch.
     /// Defaults to false.
     /// </summary>
     [YamlMember(Order = 105)]
-    [DefaultValue(false)]
-    public bool PersistCredentials { get; init; } = false;
+    public Conditioned<bool>? PersistCredentials { get; init; }
 }
 
 public record SelfCheckoutTask : CheckoutTask

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/DownloadTask.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/DownloadTask.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using Sharpliner.AzureDevOps.ConditionedExpressions;
 using YamlDotNet.Serialization;
 
 namespace Sharpliner.AzureDevOps.Tasks;
@@ -18,7 +19,7 @@ public abstract record DownloadTask : Step
     /// The name of the artifact to download. If left empty, all artifacts associated to the pipeline run will be downloaded.
     /// </summary>
     [YamlMember(Order = 60)]
-    public string? Artifact { get; init; } = null;
+    public Conditioned<string>? Artifact { get; init; }
 
     /// <summary>
     /// One or more file matching patterns (new line delimited) that limit which files get downloaded.
@@ -38,8 +39,7 @@ public abstract record DownloadTask : Step
     /// More details can be found in <see href="https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops">official Azure DevOps pipelines documentation</see>.
     /// </summary>
     [YamlMember(Order = 62)]
-    [DefaultValue("$(Pipeline.Workspace)")]
-    public string Path { get; init; } = "$(Pipeline.Workspace)";
+    public Conditioned<string>? Path { get; init; }
 
     /// <summary>
     /// A list of tags. Only builds with these tags will be returned.

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/PowerShellTask.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/PowerShellTask.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using Sharpliner.AzureDevOps.ConditionedExpressions;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 
@@ -12,7 +13,7 @@ public abstract record PowershellTask : Step
     /// If you leave it empty, the working directory is $(Build.SourcesDirectory).
     /// </summary>
     [YamlMember(Order = 113)]
-    public string? WorkingDirectory { get; init; }
+    public Conditioned<string>? WorkingDirectory { get; init; }
 
     /// <summary>
     /// Prepends the line $ErrorActionPreference = 'VALUE' at the top of your script.
@@ -60,7 +61,7 @@ public abstract record PowershellTask : Step
     /// Default value: `false`.
     /// </summary>
     [YamlMember(Order = 125)]
-    public bool FailOnStderr { get; init; } = false;
+    public Conditioned<bool>? FailOnStderr { get; init; }
 
     /// <summary>
     /// If this is false, the line if ((Test-Path -LiteralPath variable:\\LASTEXITCODE)) { exit $LASTEXITCODE } is appended to the end of your script.
@@ -69,14 +70,14 @@ public abstract record PowershellTask : Step
     /// Default value: `false`.
     /// </summary>
     [YamlMember(Order = 126)]
-    public bool IgnoreLASTEXITCODE { get; init; } = false;
+    public Conditioned<bool>? IgnoreLASTEXITCODE { get; init; }
 
     /// <summary>
     /// If this is true, then on Windows the task will use pwsh.exe from your PATH instead of powershell.exe.
     /// Default value: `false`.
     /// </summary>
     [YamlMember(Order = 127)]
-    public bool Pwsh { get; init; } = false;
+    public bool Pwsh { get; init; }
 }
 
 public record InlinePowershellTask : PowershellTask
@@ -108,7 +109,7 @@ public record PowershellFileTask : PowershellTask, IYamlConvertible
     /// <summary>
     /// Arguments passed to the Bash script.
     /// </summary>
-    public string? Arguments { get; init; }
+    public Conditioned<string>? Arguments { get; init; }
 
     public PowershellFileTask(string filePath)
     {

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/PublishTask.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/PublishTask.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using Sharpliner.AzureDevOps.ConditionedExpressions;
 using YamlDotNet.Serialization;
 
 namespace Sharpliner.AzureDevOps.Tasks;
@@ -20,7 +21,7 @@ public record PublishTask : Step
     /// Your artifact name. You can specify any name you prefer. E.g.: drop
     /// </summary>
     [YamlMember(Order = 101)]
-    public string Artifact { get; init; }
+    public Conditioned<string>? Artifact { get; init; }
 
     /// <summary>
     /// Artifacts publish location. Choose whether to store the artifact in Azure Pipelines,
@@ -35,14 +36,14 @@ public record PublishTask : Step
     /// This can include variables. Required when ArtifactType = FilePath.
     /// </summary>
     [YamlMember(Order = 211)]
-    public string? FileSharePath { get; init; }
+    public Conditioned<string>? FileSharePath { get; init; }
 
     /// <summary>
     /// Select whether to copy files in parallel using multiple threads for greater potential throughput.
     /// If this setting is not enabled, one thread will be used.
     /// </summary>
     [YamlMember(Order = 212)]
-    public bool Parallel { get; init; }
+    public Conditioned<bool>? Parallel { get; init; }
 
     /// <summary>
     /// Enter the degree of parallelism, or number of threads used, to perform the copy.

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/ScriptTask.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/ScriptTask.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Sharpliner.AzureDevOps.ConditionedExpressions;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 
@@ -20,14 +21,14 @@ public record ScriptTask : Step
     /// If you leave it empty, the working directory is $(Build.SourcesDirectory).
     /// </summary>
     [YamlMember(Order = 113)]
-    public string? WorkingDirectory { get; init; }
+    public Conditioned<string>? WorkingDirectory { get; init; }
 
     /// <summary>
     /// If this is true, this task will fail if any errors are written to stderr.
     /// Defaults to 'false'.
     /// </summary>
     [YamlMember(Order = 200)]
-    public bool FailOnStdErr { get; init; } = false;
+    public Conditioned<bool>? FailOnStdErr { get; init; }
 
     public ScriptTask(params string[] scriptLines)
     {

--- a/src/Sharpliner/AzureDevOps/Model/VariableDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/Model/VariableDefinition.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Sharpliner.AzureDevOps.ConditionedExpressions;
 using YamlDotNet.Serialization;
 
 namespace Sharpliner.AzureDevOps;
@@ -9,7 +10,7 @@ public abstract record VariableBase;
 public record VariableGroup : VariableBase
 {
     [YamlMember(Alias = "group")]
-    public string Name { get; }
+    public Conditioned<string> Name { get; }
 
     public VariableGroup(string name)
     {
@@ -20,7 +21,7 @@ public record VariableGroup : VariableBase
 public record VariableTemplate : VariableBase
 {
     [YamlMember(Alias = "template")]
-    public string Name { get; }
+    public Conditioned<string> Name { get; }
 
     public VariableTemplate(string name)
     {
@@ -37,7 +38,7 @@ public record Variable : VariableBase
     public object Value { get; }
 
     [YamlMember(Alias = "readonly", Order = 3, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
-    public bool Readonly { get; init; }
+    public Conditioned<bool>? Readonly { get; init; }
 
     private Variable(string name, object value)
     {

--- a/src/Sharpliner/AzureDevOps/Model/WebhookResource.cs
+++ b/src/Sharpliner/AzureDevOps/Model/WebhookResource.cs
@@ -21,7 +21,7 @@ public record WebhookResource
     /// Service connection for your build service
     /// </summary>
     [DisallowNull]
-    public string? Connection { get; init; }
+    public Conditioned<string>? Connection { get; init; }
 
     /// <summary>
     /// Source definition of the build
@@ -41,12 +41,12 @@ public record JsonParameterFilter
     /// <summary>
     /// JSON path in the payload
     /// </summary>
-    public string Path { get; }
+    public Conditioned<string> Path { get; }
 
     /// <summary>
     /// Expected value in the path provided
     /// </summary>
-    public string Value { get; init; }
+    public Conditioned<string> Value { get; init; }
 
     public JsonParameterFilter(string path, string value)
     {

--- a/tests/Sharpliner.Tests/AzureDevOps/ConditionedExpressions/ConditionedTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/ConditionedExpressions/ConditionedTests.cs
@@ -1,0 +1,36 @@
+﻿using FluentAssertions;
+using Sharpliner.AzureDevOps;
+using Sharpliner.AzureDevOps.ConditionedExpressions;
+using Xunit;
+
+namespace Sharpliner.Tests.AzureDevOps.ConditionedExpressions;
+
+public class ConditionedTests
+{
+    private class Equality_Test_Pipeline : SingleStagePipelineDefinition
+    {
+        public static VariableReference Variable1 => variables["foo"];
+        public static VariableReference Variable2 => variables["bar"];
+
+        public static ParameterReference Parameter1 => parameters["Xyz"];
+        public static ParameterReference Parameter2 => parameters["Unn"];
+
+        public static Conditioned<string> Conditioned1 => "foo";
+        public static Conditioned<string> Conditioned2 => "bar";
+
+        public override string TargetFile => throw new System.NotImplementedException();
+
+        public override SingleStagePipeline Pipeline => throw new System.NotImplementedException();
+    }
+    
+    [Fact]
+    public void Equality_Test()
+    {
+        Equality_Test_Pipeline.Variable1.Should().Be(Equality_Test_Pipeline.Variable1);
+        Equality_Test_Pipeline.Variable1.Should().NotBe(Equality_Test_Pipeline.Variable2);
+        Equality_Test_Pipeline.Parameter1.Should().Be(Equality_Test_Pipeline.Parameter1);
+        Equality_Test_Pipeline.Parameter1.Should().NotBe(Equality_Test_Pipeline.Parameter2);
+        Equality_Test_Pipeline.Conditioned1.Should().Be(Equality_Test_Pipeline.Conditioned1);
+        Equality_Test_Pipeline.Conditioned1.Should().NotBe(Equality_Test_Pipeline.Conditioned2);
+    }
+}

--- a/tests/Sharpliner.Tests/AzureDevOps/Model/Tasks/TaskBuilderTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/Model/Tasks/TaskBuilderTests.cs
@@ -216,6 +216,7 @@ public class TaskBuilderTests
           - publish: bin/Debug/net5.0/
             displayName: Publish artifact
             artifact: Binary
+            continueOnError: false
         """);
     }
 

--- a/tests/Sharpliner.Tests/AzureDevOps/ParameterReferenceTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/ParameterReferenceTests.cs
@@ -40,6 +40,11 @@ public class ParameterReferenceTests
                                 .Step(parameters["steps"]),
 
                             parameters["steps"],
+
+                            Bash.Inline("curl -o $(Agent.TempDirectory)/sharpliner.zip") with
+                            {
+                                ContinueOnError = parameters["continue"],
+                            }
                         }
                     },
 
@@ -85,7 +90,11 @@ public class ParameterReferenceTests
                 steps:
                 - ${{ parameters.steps }}
                 - ${{ parameters.steps }}
-            
+
+                - bash: |-
+                    curl -o $(Agent.TempDirectory)/sharpliner.zip
+                  continueOnError: ${{ parameters.continue }}
+
               - ${{ parameters.jobs }}
             - ${{ parameters.stages }}
             """);

--- a/tests/Sharpliner.Tests/AzureDevOps/VariableReferenceTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/VariableReferenceTests.cs
@@ -1,0 +1,71 @@
+﻿using FluentAssertions;
+using Sharpliner.AzureDevOps;
+using Sharpliner.AzureDevOps.ConditionedExpressions;
+using Xunit;
+
+namespace Sharpliner.Tests.AzureDevOps;
+
+public class VariableReferenceTests
+{
+    private class VariableReferenceTest_Template : StageTemplateDefinition
+    {
+        public override string TargetFile => "stages.yml";
+
+        public override ConditionedList<Stage> Definition => new()
+        {
+            new Stage("Stage_1")
+            {
+                Jobs =
+                {
+                    new Job("Job_1")
+                    {
+                        Pool = variables["pool"],
+
+                        Steps =
+                        {
+                            If.Equal(variables["agentOs"], "Windows_NT")
+                                .Step(variables["steps"]),
+
+                            variables["steps"],
+
+                            Bash.Inline("curl -o $(Agent.TempDirectory)/sharpliner.zip") with
+                            {
+                                ContinueOnError = variables["continue"],
+                            }
+                        }
+                    },
+
+                    variables["jobs"],
+                }
+            },
+
+            variables["stages"],
+        };
+    }
+
+    // This tests that we can include variables at any point of the pipeline
+    [Fact]
+    public void PipelineVariable_Serialization_Test()
+    {
+        var yaml = new VariableReferenceTest_Template().Serialize();
+
+        yaml.Trim().Should().Be(
+            """
+            stages:
+            - stage: Stage_1
+              jobs:
+              - job: Job_1
+                pool: ${{ variables['pool'] }}
+                steps:
+                - ${{ variables['steps'] }}
+                - ${{ variables['steps'] }}
+
+                - bash: |-
+                    curl -o $(Agent.TempDirectory)/sharpliner.zip
+                  continueOnError: ${{ variables['continue'] }}
+
+              - ${{ variables['jobs'] }}
+            - ${{ variables['stages'] }}
+            """);
+    }
+}

--- a/tests/Sharpliner.Tests/PublicApiExport.txt
+++ b/tests/Sharpliner.Tests/PublicApiExport.txt
@@ -132,13 +132,13 @@
     public class BuildResource : System.IEquatable<Sharpliner.AzureDevOps.BuildResource>
     {
         public BuildResource(string identifier) { }
-        public string? Connection { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? Connection { get; set; }
         [YamlDotNet.Serialization.YamlMember(Alias="build")]
         public string Identifier { get; }
-        public string? Source { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? Source { get; set; }
         public bool Trigger { get; set; }
-        public string? Type { get; set; }
-        public string? Version { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? Type { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? Version { get; set; }
     }
     public sealed class BuildVariableReference : Sharpliner.AzureDevOps.VariableReferenceBase
     {
@@ -295,21 +295,21 @@
         public ContainerReference() { }
         public string? Endpoint { get; set; }
         public Sharpliner.AzureDevOps.ConditionedExpressions.ConditionedDictionary Env { get; set; }
-        public string? Image { get; set; }
-        public string? Options { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? Image { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? Options { get; set; }
     }
     public class ContainerResource : System.IEquatable<Sharpliner.AzureDevOps.ContainerResource>
     {
         public ContainerResource(string identifier) { }
-        public string? Endpoint { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? Endpoint { get; set; }
         public Sharpliner.AzureDevOps.ConditionedExpressions.ConditionedDictionary Env { get; set; }
         [YamlDotNet.Serialization.YamlMember(Alias="container")]
         public string Identifier { get; }
-        public string? Image { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? Image { get; set; }
         [System.ComponentModel.DefaultValue(true)]
         public bool MapDockerSocket { get; set; }
         public Sharpliner.AzureDevOps.ContainerMountSettings? MountReadOnly { get; set; }
-        public string? Options { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? Options { get; set; }
         public System.Collections.Generic.List<string> Ports { get; set; }
         public System.Collections.Generic.List<string> Volumes { get; set; }
     }
@@ -374,7 +374,7 @@
         [YamlDotNet.Serialization.YamlMember(Order=110)]
         public Sharpliner.AzureDevOps.ConditionedExpressions.ConditionedList<string> Demands { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=105)]
-        public string? VmImage { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? VmImage { get; set; }
     }
     public interface IDependsOn
     {
@@ -452,19 +452,19 @@
     {
         protected JobBase(string name, string? displayName = null) { }
         [YamlDotNet.Serialization.YamlIgnore]
-        public System.TimeSpan? CancelTimeout { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<System.TimeSpan>? CancelTimeout { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=900)]
-        public int? CancelTimeoutInMinutes { get; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<int>? CancelTimeoutInMinutes { get; }
         [YamlDotNet.Serialization.YamlMember(Order=1100)]
-        public Sharpliner.AzureDevOps.InlineCondition? Condition { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.InlineCondition>? Condition { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=500)]
         public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.ContainerReference>? Container { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=1200)]
-        public bool ContinueOnError { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<bool>? ContinueOnError { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=200)]
         public Sharpliner.AzureDevOps.ConditionedExpressions.ConditionedList<string> DependsOn { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=100)]
-        public string? DisplayName { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? DisplayName { get; set; }
         [YamlDotNet.Serialization.YamlIgnore]
         public string Name { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=300)]
@@ -472,9 +472,9 @@
         [YamlDotNet.Serialization.YamlMember(Order=1100)]
         public System.Collections.Generic.Dictionary<string, string> Services { get; set; }
         [YamlDotNet.Serialization.YamlIgnore]
-        public System.TimeSpan? Timeout { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<System.TimeSpan>? Timeout { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=800)]
-        public int? TimeoutInMinutes { get; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<int>? TimeoutInMinutes { get; }
         [YamlDotNet.Serialization.YamlMember(Order=600)]
         public Sharpliner.AzureDevOps.ConditionedExpressions.ConditionedList<Sharpliner.AzureDevOps.VariableBase> Variables { get; set; }
         [System.ComponentModel.DefaultValue(Sharpliner.AzureDevOps.JobWorkspace.Outputs)]
@@ -512,8 +512,8 @@
     public class JsonParameterFilter : System.IEquatable<Sharpliner.AzureDevOps.JsonParameterFilter>
     {
         public JsonParameterFilter(string path, string value) { }
-        public string Path { get; }
-        public string Value { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string> Path { get; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string> Value { get; set; }
     }
     public class LibraryReference<T> : Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<T>, System.IEquatable<Sharpliner.AzureDevOps.LibraryReference<T>>
     {
@@ -584,7 +584,7 @@
     public abstract class PackageResource : System.IEquatable<Sharpliner.AzureDevOps.PackageResource>
     {
         public PackageResource(string packageAlias, string packageName) { }
-        public string? Connection { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? Connection { get; set; }
         public string Name { get; set; }
         [YamlDotNet.Serialization.YamlMember(Alias="package")]
         public string PackageAlias { get; }
@@ -596,7 +596,7 @@
     public class ParallelStrategy : Sharpliner.AzureDevOps.Strategy, System.IEquatable<Sharpliner.AzureDevOps.ParallelStrategy>
     {
         public ParallelStrategy() { }
-        public int Parallel { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<int>? Parallel { get; set; }
     }
     public abstract class Parameter : System.IEquatable<Sharpliner.AzureDevOps.Parameter>
     {
@@ -704,7 +704,7 @@
     {
         public Pool(string? name) { }
         [YamlDotNet.Serialization.YamlMember(Order=100)]
-        public string? Name { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? Name { get; set; }
         public static Sharpliner.AzureDevOps.Pool op_Implicit(string vmImage) { }
     }
     public class PrTrigger : System.IEquatable<Sharpliner.AzureDevOps.PrTrigger>
@@ -735,8 +735,8 @@
         public string? Endpoint { get; set; }
         [YamlDotNet.Serialization.YamlMember(Alias="repository")]
         public string Identifier { get; }
-        public string? Name { get; set; }
-        public string? Ref { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? Name { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? Ref { get; set; }
         public Sharpliner.AzureDevOps.Trigger? Trigger { get; set; }
         public Sharpliner.AzureDevOps.RepositoryType Type { get; set; }
         public static Sharpliner.AzureDevOps.RepositoryResource AzureDevOps(string identifier, string project, string repoName, string? endpoint = null, string? refName = null) { }
@@ -802,13 +802,13 @@
         public ScheduledTrigger(string cronSchedule, params string[] branches) { }
         public ScheduledTrigger(string minute, string hour, string dayOfMonth, string month, string dayOfWeek, params string[] branches) { }
         [YamlDotNet.Serialization.YamlMember(Order=300)]
-        public bool Always { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<bool>? Always { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=200)]
         public Sharpliner.AzureDevOps.InclusionRule? Branches { get; set; }
         [YamlDotNet.Serialization.YamlMember(Alias="cron", Order=1)]
-        public string? CronSchedule { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? CronSchedule { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=100)]
-        public string? DisplayName { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? DisplayName { get; set; }
     }
     public class ServerPool : Sharpliner.AzureDevOps.Pool, System.IEquatable<Sharpliner.AzureDevOps.ServerPool>, YamlDotNet.Serialization.IYamlConvertible
     {
@@ -874,22 +874,22 @@
     {
         protected Step() { }
         [YamlDotNet.Serialization.YamlMember(Order=190)]
-        public Sharpliner.AzureDevOps.InlineCondition? Condition { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.InlineCondition>? Condition { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=200)]
-        public bool ContinueOnError { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<bool>? ContinueOnError { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=100)]
-        public string? DisplayName { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? DisplayName { get; set; }
         [System.ComponentModel.DefaultValue(true)]
         [YamlDotNet.Serialization.YamlMember(Order=175)]
         public bool Enabled { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=220)]
         public Sharpliner.AzureDevOps.ConditionedExpressions.ConditionedDictionary Env { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=150)]
-        public string? Name { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? Name { get; set; }
         [YamlDotNet.Serialization.YamlIgnore]
-        public System.TimeSpan? Timeout { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<System.TimeSpan>? Timeout { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=210)]
-        public int? TimeoutInMinutes { get; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<int>? TimeoutInMinutes { get; }
         public Sharpliner.AzureDevOps.Step DisplayAs(string displayName) { }
         public Sharpliner.AzureDevOps.Step When(string condition) { }
         public Sharpliner.AzureDevOps.Step WhenSucceeded() { }
@@ -921,7 +921,7 @@
     public abstract class Strategy : System.IEquatable<Sharpliner.AzureDevOps.Strategy>
     {
         protected Strategy() { }
-        public int MaxParallel { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<int>? MaxParallel { get; set; }
     }
     public sealed class StrategyVariableReference : Sharpliner.AzureDevOps.VariableReferenceBase
     {
@@ -1048,7 +1048,7 @@
         [YamlDotNet.Serialization.YamlMember(Alias="name", Order=1)]
         public string Name { get; }
         [YamlDotNet.Serialization.YamlMember(Alias="readonly", DefaultValuesHandling=YamlDotNet.Serialization.DefaultValuesHandling.Preserve | YamlDotNet.Serialization.DefaultValuesHandling.OmitDefaults, Order=3)]
-        public bool Readonly { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<bool>? Readonly { get; set; }
         [YamlDotNet.Serialization.YamlMember(Alias="value", DefaultValuesHandling=YamlDotNet.Serialization.DefaultValuesHandling.Preserve, Order=2)]
         public object Value { get; }
         public Sharpliner.AzureDevOps.Variable ReadOnly() { }
@@ -1061,7 +1061,7 @@
     {
         public VariableGroup(string name) { }
         [YamlDotNet.Serialization.YamlMember(Alias="group")]
-        public string Name { get; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string> Name { get; }
     }
     public abstract class VariableLibrary : Sharpliner.AzureDevOps.DefinitionLibrary<Sharpliner.AzureDevOps.VariableBase>
     {
@@ -1079,7 +1079,7 @@
     {
         public VariableTemplate(string name) { }
         [YamlDotNet.Serialization.YamlMember(Alias="template")]
-        public string Name { get; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string> Name { get; }
     }
     public abstract class VariableTemplateCollection : Sharpliner.AzureDevOps.TemplateDefinitionCollection<Sharpliner.AzureDevOps.VariableBase>
     {
@@ -1106,7 +1106,7 @@
     public class WebhookResource : System.IEquatable<Sharpliner.AzureDevOps.WebhookResource>
     {
         public WebhookResource(string identifier) { }
-        public string? Connection { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? Connection { get; set; }
         public Sharpliner.AzureDevOps.ConditionedExpressions.ConditionedList<Sharpliner.AzureDevOps.JsonParameterFilter> Filters { get; set; }
         [YamlDotNet.Serialization.YamlMember(Alias="webhook")]
         public string Identifier { get; }
@@ -1196,6 +1196,11 @@ namespace Sharpliner.AzureDevOps.ConditionedExpressions
     public class ConditionedParameterReference<T> : Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<T>, System.IEquatable<Sharpliner.AzureDevOps.ConditionedExpressions.ConditionedParameterReference<T>>
     {
         public ConditionedParameterReference(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference parameter) { }
+        public override void Write(YamlDotNet.Core.IEmitter emitter, YamlDotNet.Serialization.ObjectSerializer nestedObjectSerializer) { }
+    }
+    public class ConditionedVariableReference<T> : Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<T>, System.IEquatable<Sharpliner.AzureDevOps.ConditionedExpressions.ConditionedVariableReference<T>>
+    {
+        public ConditionedVariableReference(Sharpliner.AzureDevOps.ConditionedExpressions.VariableReference variable) { }
         public override void Write(YamlDotNet.Core.IEmitter emitter, YamlDotNet.Serialization.ObjectSerializer nestedObjectSerializer) { }
     }
     public class Conditioned<T> : Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned, System.IEquatable<Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<T>>
@@ -1351,10 +1356,19 @@ namespace Sharpliner.AzureDevOps.ConditionedExpressions
         public string CompileTimeExpression { get; }
         public string ParameterName { get; }
         public string RuntimeExpression { get; }
+        public override bool Equals(object? obj) { }
+        public override int GetHashCode() { }
         public void Read(YamlDotNet.Core.IParser parser, System.Type expectedType, YamlDotNet.Serialization.ObjectDeserializer nestedObjectDeserializer) { }
         public override string ToString() { }
         public void Write(YamlDotNet.Core.IEmitter emitter, YamlDotNet.Serialization.ObjectSerializer nestedObjectSerializer) { }
         public static string op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<int> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<bool> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<System.TimeSpan> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.TemplateParameters> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.ConditionedExpressions.ConditionedDictionary> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.InlineCondition> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.VariableBase> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Stage> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.JobBase> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
@@ -1367,10 +1381,24 @@ namespace Sharpliner.AzureDevOps.ConditionedExpressions
         public string MacroExpression { get; }
         public string RuntimeExpression { get; }
         public string VariableName { get; }
+        public override bool Equals(object? obj) { }
+        public override int GetHashCode() { }
         public void Read(YamlDotNet.Core.IParser parser, System.Type expectedType, YamlDotNet.Serialization.ObjectDeserializer nestedObjectDeserializer) { }
         public override string ToString() { }
         public void Write(YamlDotNet.Core.IEmitter emitter, YamlDotNet.Serialization.ObjectSerializer nestedObjectSerializer) { }
         public static string op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.VariableReference value) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<int> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.VariableReference value) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<bool> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.VariableReference value) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.VariableReference value) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<System.TimeSpan> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.VariableReference value) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.TemplateParameters> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.VariableReference value) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.ConditionedExpressions.ConditionedDictionary> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.VariableReference value) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.InlineCondition> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.VariableReference value) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.VariableBase> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.VariableReference value) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Stage> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.VariableReference value) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.JobBase> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.VariableReference value) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Step> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.VariableReference value) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Pool> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.VariableReference value) { }
     }
 }
 namespace Sharpliner.AzureDevOps.ConditionedExpressions.Interfaces
@@ -1421,8 +1449,8 @@ namespace Sharpliner.AzureDevOps.Tasks
     public class BashFileTask : Sharpliner.AzureDevOps.Tasks.BashTask, System.IEquatable<Sharpliner.AzureDevOps.Tasks.BashFileTask>, YamlDotNet.Serialization.IYamlConvertible
     {
         public BashFileTask(string filePath) { }
-        public string? Arguments { get; set; }
-        public string? BashEnv { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? Arguments { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? BashEnv { get; set; }
         public string FilePath { get; }
         public void Read(YamlDotNet.Core.IParser parser, System.Type expectedType, YamlDotNet.Serialization.ObjectDeserializer nestedObjectDeserializer) { }
         public void Write(YamlDotNet.Core.IEmitter emitter, YamlDotNet.Serialization.ObjectSerializer nestedObjectSerializer) { }
@@ -1431,14 +1459,14 @@ namespace Sharpliner.AzureDevOps.Tasks
     {
         protected BashTask() { }
         [YamlDotNet.Serialization.YamlMember(Order=114)]
-        public bool FailOnStderr { get; set; }
+        public bool? FailOnStderr { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=115)]
-        public bool NoProfile { get; set; }
+        public bool? NoProfile { get; set; }
         [System.ComponentModel.DefaultValue(true)]
         [YamlDotNet.Serialization.YamlMember(Order=200)]
         public bool NoRc { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=113)]
-        public string? WorkingDirectory { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? WorkingDirectory { get; set; }
     }
     public class BashTaskBuilder : Sharpliner.Common.Model.Tasks.TaskBuilderBase
     {
@@ -1460,21 +1488,16 @@ namespace Sharpliner.AzureDevOps.Tasks
         protected CheckoutTask() { }
         [YamlDotNet.Serialization.YamlMember(Order=1)]
         public abstract string Checkout { get; }
-        [System.ComponentModel.DefaultValue(false)]
         [YamlDotNet.Serialization.YamlMember(Order=100)]
-        public bool Clean { get; set; }
-        [System.ComponentModel.DefaultValue(1)]
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<bool>? Clean { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=101)]
-        public int FetchDepth { get; set; }
-        [System.ComponentModel.DefaultValue(false)]
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<int>? FetchDepth { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=102)]
-        public bool Lfs { get; set; }
-        [System.ComponentModel.DefaultValue("s")]
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<bool>? Lfs { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=104)]
-        public string Path { get; set; }
-        [System.ComponentModel.DefaultValue(false)]
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? Path { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=105)]
-        public bool PersistCredentials { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<bool>? PersistCredentials { get; set; }
         [System.ComponentModel.DefaultValue(Sharpliner.AzureDevOps.Tasks.SubmoduleCheckout.None)]
         [YamlDotNet.Serialization.YamlMember(Order=103)]
         public Sharpliner.AzureDevOps.Tasks.SubmoduleCheckout Submodules { get; set; }
@@ -1606,12 +1629,11 @@ namespace Sharpliner.AzureDevOps.Tasks
     {
         protected DownloadTask() { }
         [YamlDotNet.Serialization.YamlMember(Order=60)]
-        public string? Artifact { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? Artifact { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=1)]
         public abstract string Download { get; }
-        [System.ComponentModel.DefaultValue("$(Pipeline.Workspace)")]
         [YamlDotNet.Serialization.YamlMember(Order=62)]
-        public string Path { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? Path { get; set; }
         [YamlDotNet.Serialization.YamlIgnore]
         public System.Collections.Generic.List<string> Patterns { get; set; }
         [YamlDotNet.Serialization.YamlIgnore]
@@ -1658,7 +1680,7 @@ namespace Sharpliner.AzureDevOps.Tasks
     public class PowershellFileTask : Sharpliner.AzureDevOps.Tasks.PowershellTask, System.IEquatable<Sharpliner.AzureDevOps.Tasks.PowershellFileTask>, YamlDotNet.Serialization.IYamlConvertible
     {
         public PowershellFileTask(string filePath) { }
-        public string? Arguments { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? Arguments { get; set; }
         public string FilePath { get; }
         public void Read(YamlDotNet.Core.IParser parser, System.Type expectedType, YamlDotNet.Serialization.ObjectDeserializer nestedObjectDeserializer) { }
         public void Write(YamlDotNet.Core.IEmitter emitter, YamlDotNet.Serialization.ObjectSerializer nestedObjectSerializer) { }
@@ -1673,9 +1695,9 @@ namespace Sharpliner.AzureDevOps.Tasks
         [YamlDotNet.Serialization.YamlMember(Order=114)]
         public Sharpliner.AzureDevOps.Tasks.ActionPreference ErrorActionPreference { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=125)]
-        public bool FailOnStderr { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<bool>? FailOnStderr { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=126)]
-        public bool IgnoreLASTEXITCODE { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<bool>? IgnoreLASTEXITCODE { get; set; }
         [System.ComponentModel.DefaultValue(Sharpliner.AzureDevOps.Tasks.ActionPreference.Continue)]
         [YamlDotNet.Serialization.YamlMember(Order=114)]
         public Sharpliner.AzureDevOps.Tasks.ActionPreference InformationPreference { get; set; }
@@ -1688,7 +1710,7 @@ namespace Sharpliner.AzureDevOps.Tasks
         [YamlDotNet.Serialization.YamlMember(Order=114)]
         public Sharpliner.AzureDevOps.Tasks.ActionPreference WarningPreference { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=113)]
-        public string? WorkingDirectory { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? WorkingDirectory { get; set; }
     }
     public class PowershellTaskBuilder : Sharpliner.Common.Model.Tasks.TaskBuilderBase
     {
@@ -1701,14 +1723,14 @@ namespace Sharpliner.AzureDevOps.Tasks
     {
         public PublishTask(string targetPath, string artifactName = "drop") { }
         [YamlDotNet.Serialization.YamlMember(Order=101)]
-        public string Artifact { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? Artifact { get; set; }
         [System.ComponentModel.DefaultValue(Sharpliner.AzureDevOps.Tasks.ArtifactType.Pipeline)]
         [YamlDotNet.Serialization.YamlMember(Order=102)]
         public Sharpliner.AzureDevOps.Tasks.ArtifactType ArtifactType { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=211)]
-        public string? FileSharePath { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? FileSharePath { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=212)]
-        public bool Parallel { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<bool>? Parallel { get; set; }
         [System.ComponentModel.DefaultValue(1u)]
         [YamlDotNet.Serialization.YamlMember(Order=213)]
         public uint ParallelCount { get; set; }
@@ -1732,9 +1754,9 @@ namespace Sharpliner.AzureDevOps.Tasks
         [YamlDotNet.Serialization.YamlMember(Alias="script", Order=1, ScalarStyle=YamlDotNet.Core.ScalarStyle.Literal)]
         public string Contents { get; }
         [YamlDotNet.Serialization.YamlMember(Order=200)]
-        public bool FailOnStdErr { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<bool>? FailOnStdErr { get; set; }
         [YamlDotNet.Serialization.YamlMember(Order=113)]
-        public string? WorkingDirectory { get; set; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? WorkingDirectory { get; set; }
     }
     public class ScriptTaskBuilder : Sharpliner.Common.Model.Tasks.TaskBuilderBase
     {


### PR DESCRIPTION
This adds the possibility to use `variables['foo']` in place of other types. It also makes it possible to use the if statement everywhere.

Resolves #266