### PR TITLE
Add a support for `${{ each }}` expressions

### DIFF
--- a/docs/AzureDevOps/DefinitionReference.md
+++ b/docs/AzureDevOps/DefinitionReference.md
@@ -274,6 +274,47 @@ If.And(IsNotPullRequest, IsBranch("production"))
 If.Condition("containsValue(...)")
 ```
 
+## Each expression
+
+The `${{ each var in collection }}` expression is also supported. Similarly to `If` and `EndIf`, you can use `Each` and `EndEach`:
+
+```csharp
+Stages =
+{
+    If.IsBranch("main")
+        .Each("env", "parameters.stages")
+            .Stage(new Stage("stage-${{ env.name }}"))
+            .Stage(new Stage("stage2-${{ env.name }}")
+            {
+                Jobs =
+                {
+                    Each("foo", "bar")
+                        .Job(new Job("job-${{ foo }}"))
+                    .EndEach
+                    .If.Equal("foo", "bar")
+                        .Job(new Job("job2-${{ foo }}"))
+                }
+            })
+}
+```
+
+generates the following YAML:
+
+```yaml
+stages:
+- ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+  - ${{ each env in parameters.stages }}:
+    - stage: stage-${{ env.name }}
+
+    - stage: stage2-${{ env.name }}
+      jobs:
+      - ${{ each foo in bar }}:
+        - job: job-${{ foo }}
+
+      - ${{ if eq('foo', 'bar') }}:
+        - job: job2-${{ foo }}
+```
+
 ## Templates
 
 Azure pipelines allow you to [define a parametrized template](https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#template-references) for a **stage**, **job**, **step** or **variables** and then insert those templates in your pipeline.

--- a/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
@@ -478,7 +478,7 @@ public abstract class AzureDevOpsDefinition
 
     #endregion
 
-    #region Conditions
+    #region Conditions, each expressions, ..
 
     /// <summary>
     /// Start an ${{ if () }} section.
@@ -561,6 +561,11 @@ public abstract class AzureDevOpsDefinition
     protected static InlineCondition IsPullRequest => new InlineBuildReasonCondition("PullRequest", true);
 
     protected static InlineCondition IsNotPullRequest => new InlineBuildReasonCondition("PullRequest", false);
+
+    /// <summary>
+    /// Start an ${{ each var in collection }} section.
+    /// </summary>
+    protected static EachExpression Each(string iterator, string collection) => new(iterator, collection);
 
     #endregion
 

--- a/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
@@ -565,7 +565,7 @@ public abstract class AzureDevOpsDefinition
     /// <summary>
     /// Start an ${{ each var in collection }} section.
     /// </summary>
-    protected static EachExpression Each(string iterator, string collection) => new(iterator, collection);
+    protected static EachBlock Each(string iterator, string collection) => new(iterator, collection);
 
     #endregion
 

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/Condition.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/Condition.cs
@@ -15,8 +15,9 @@ namespace Sharpliner.AzureDevOps.ConditionedExpressions;
 /// </summary>
 public abstract class Condition : IYamlConvertible
 {
-    protected Condition()
+    public Condition()
     {
+        // TODO: Remove
     }
 
     internal abstract string Serialize();
@@ -35,6 +36,13 @@ public abstract class Condition : IYamlConvertible
     internal virtual string TagEnd => ExpressionEnd;
 
     internal Conditioned? Parent { get; set; }
+
+    internal EachExpression? EachExpression
+    {
+        get;
+        set;
+    }
+
 
     public static implicit operator string(Condition value) => value.Serialize();
     public override string ToString() => this;

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/Condition.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/Condition.cs
@@ -15,12 +15,11 @@ namespace Sharpliner.AzureDevOps.ConditionedExpressions;
 /// </summary>
 public abstract class Condition : IYamlConvertible
 {
-    internal abstract string Serialize();
-
     internal const string ExpressionStart = "${{ ";
+    internal const string ExpressionEnd = " }}";
+
     protected const string IfTagStart = $"{ExpressionStart}if ";
     protected const string ElseTagStart = $"{ExpressionStart}else";
-    internal const string ExpressionEnd = " }}";
 
     private const string VariableIndexAccessStart = "variables[";
     private const string VariablePropertyAccessStart = "variables.";
@@ -37,6 +36,8 @@ public abstract class Condition : IYamlConvertible
         get;
         set;
     }
+
+    internal abstract string Serialize();
 
     public static implicit operator string(Condition value) => value.Serialize();
     public override string ToString() => this;

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/Condition.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/Condition.cs
@@ -15,11 +15,6 @@ namespace Sharpliner.AzureDevOps.ConditionedExpressions;
 /// </summary>
 public abstract class Condition : IYamlConvertible
 {
-    public Condition()
-    {
-        // TODO: Remove
-    }
-
     internal abstract string Serialize();
 
     internal const string ExpressionStart = "${{ ";
@@ -42,7 +37,6 @@ public abstract class Condition : IYamlConvertible
         get;
         set;
     }
-
 
     public static implicit operator string(Condition value) => value.Serialize();
     public override string ToString() => this;

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/ConditionExtensions.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/ConditionExtensions.cs
@@ -316,4 +316,10 @@ public static class ConditionExtensions
 
     public static Conditioned<T> Value<T>(this IfCondition condition, T value)
         => Conditioned.Link(condition, value);
+
+    public static IfCondition Each(this IfCondition condition, string iterator, string collection)
+    {
+        condition.EachExpression = new(iterator, collection);
+        return condition;
+    }
 }

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/Conditioned.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/Conditioned.cs
@@ -197,7 +197,7 @@ public record Conditioned<T> : Conditioned
             // If we're top-level, we create a fake new top with empty definition to collect all the definitions
             if (Parent == null)
             {
-                Parent = new Conditioned<T>(Condition);
+                Parent = new Conditioned<T>();
                 Parent.Definitions.Add(this);
             }
 

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/Conditioned.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/Conditioned.cs
@@ -316,6 +316,13 @@ public record Conditioned<T> : Conditioned
             emitter.Emit(new SequenceStart(AnchorName.Empty, TagName.Empty, true, SequenceStyle.Block));
         }
 
+        if (Condition?.EachExpression != null)
+        {
+            emitter.Emit(new MappingStart());
+            emitter.Emit(new Scalar(Condition.EachExpression.ToString()));
+            emitter.Emit(new SequenceStart(AnchorName.Empty, TagName.Empty, true, SequenceStyle.Block));
+        }
+
         // We are first serializing us. We can be
         //   - a condition-less definition (top level or leaf) => serialize value inside Definition
         //   - a template => serialize the special shape of template + parameters
@@ -325,6 +332,12 @@ public record Conditioned<T> : Conditioned
         foreach (var childDefinition in Definitions)
         {
             nestedObjectSerializer(childDefinition);
+        }
+
+        if (Condition?.EachExpression != null)
+        {
+            emitter.Emit(new SequenceEnd());
+            emitter.Emit(new MappingEnd());
         }
 
         if (Condition != null)

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/Conditioned.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/Conditioned.cs
@@ -178,7 +178,33 @@ public record Conditioned<T> : Conditioned
             }
 
             return Parent as Conditioned<T>
-                ?? throw new InvalidOperationException("You have called EndIf on a top-level statement, EndIf can only be used to return from a nested definition");
+                ?? throw new InvalidOperationException(
+                    $"You have called {nameof(EndIf)} on a top-level statement, " +
+                    $"{nameof(EndIf)} can only be used to return from a nested definition");
+        }
+    }
+
+    public Conditioned<T> EndEach
+    {
+        get
+        {
+            if (Condition?.EachExpression != null)
+            {
+                Condition.EachExpression = null;
+                return this;
+            }
+
+            // If we're top-level, we create a fake new top with empty definition to collect all the definitions
+            if (Parent == null)
+            {
+                Parent = new Conditioned<T>(Condition);
+                Parent.Definitions.Add(this);
+            }
+
+            return Parent as Conditioned<T>
+                ?? throw new InvalidOperationException(
+                    $"You have called {nameof(EndEach)} on a top-level statement, " +
+                    $"{nameof(EndEach)} must only be used after Each");
         }
     }
 
@@ -252,6 +278,12 @@ public record Conditioned<T> : Conditioned
         }
         else if (Definitions.Count > 0)
         {
+            emitter.Emit(new MappingStart());
+        }
+
+        if (Condition?.EachExpression != null)
+        {
+            emitter.Emit(new Scalar(Condition.EachExpression.ToString()));
             emitter.Emit(new MappingStart());
         }
 

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/ConditionedExtensions.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/ConditionedExtensions.cs
@@ -104,37 +104,37 @@ public static class ConditionedExtensions
     /// <summary>
     /// Creates a new stage.
     /// </summary>
-    public static Conditioned<Stage> Stage(this Conditioned<Stage> condition, Stage stage)
+    public static Conditioned<Stage> Stage(this Conditioned<Stage> conditionedDefinition, Stage stage)
     {
-        condition.Definitions.Add(new Conditioned<Stage>(definition: stage));
-        return condition;
+        conditionedDefinition.Definitions.Add(new Conditioned<Stage>(definition: stage));
+        return conditionedDefinition;
     }
 
     /// <summary>
     /// Creates a new step.
     /// </summary>
-    public static Conditioned<Step> Step(this Conditioned<Step> condition, Step step)
+    public static Conditioned<Step> Step(this Conditioned<Step> conditionedDefinition, Step step)
     {
-        condition.Definitions.Add(new Conditioned<Step>(definition: step));
-        return condition;
+        conditionedDefinition.Definitions.Add(new Conditioned<Step>(definition: step));
+        return conditionedDefinition;
     }
 
     /// <summary>
     /// Creates a new job.
     /// </summary>
-    public static Conditioned<JobBase> Job(this Conditioned<JobBase> condition, JobBase job)
+    public static Conditioned<JobBase> Job(this Conditioned<JobBase> conditionedDefinition, JobBase job)
     {
-        condition.Definitions.Add(new Conditioned<JobBase>(definition: job));
-        return condition;
+        conditionedDefinition.Definitions.Add(new Conditioned<JobBase>(definition: job));
+        return conditionedDefinition;
     }
 
     /// <summary>
     /// Creates a new deployment job.
     /// </summary>
-    public static Conditioned<JobBase> DeploymentJob(this Conditioned<JobBase> condition, JobBase job)
+    public static Conditioned<JobBase> DeploymentJob(this Conditioned<JobBase> conditionedDefinition, JobBase job)
     {
-        condition.Definitions.Add(new Conditioned<JobBase>(definition: job));
-        return condition;
+        conditionedDefinition.Definitions.Add(new Conditioned<JobBase>(definition: job));
+        return conditionedDefinition;
     }
 
     /// <summary>

--- a/src/Sharpliner/AzureDevOps/EachExpression.cs
+++ b/src/Sharpliner/AzureDevOps/EachExpression.cs
@@ -8,10 +8,13 @@ public class EachExpression(string iterator, string collection)
     public string Collection { get; } = collection;
 
     public override string ToString()
-        => $"{Condition.ExpressionStart}each {Iterator} in {Collection}{Condition.ExpressionEnd}";
+        => $"{Condition.ExpressionStart}{GetEachExpression(Iterator, Collection)}{Condition.ExpressionEnd}";
+
+    internal static string GetEachExpression(string iterator, string collection)
+        => $"each {iterator} in {collection}";
 }
 
-public class EachBlock(string iterator, string collection) : Condition
+public class EachBlock(string iterator, string collection) : IfCondition
 {
-    internal override string Serialize() => throw new System.NotImplementedException();
+    internal override string Serialize() => WrapTag(EachExpression.GetEachExpression(iterator, collection));
 }

--- a/src/Sharpliner/AzureDevOps/EachExpression.cs
+++ b/src/Sharpliner/AzureDevOps/EachExpression.cs
@@ -8,5 +8,10 @@ public class EachExpression(string iterator, string collection)
     public string Collection { get; } = collection;
 
     public override string ToString()
-        => $"{Condition.ExpressionStart} each {Iterator} in {Collection} {Condition.ExpressionEnd}";
+        => $"{Condition.ExpressionStart}each {Iterator} in {Collection}{Condition.ExpressionEnd}";
+}
+
+public class EachBlock(string iterator, string collection) : Condition
+{
+    internal override string Serialize() => throw new System.NotImplementedException();
 }

--- a/src/Sharpliner/AzureDevOps/EachExpression.cs
+++ b/src/Sharpliner/AzureDevOps/EachExpression.cs
@@ -1,0 +1,12 @@
+﻿using Sharpliner.AzureDevOps.ConditionedExpressions;
+
+namespace Sharpliner.AzureDevOps;
+
+public class EachExpression(string iterator, string collection)
+{
+    public string Iterator { get; } = iterator;
+    public string Collection { get; } = collection;
+
+    public override string ToString()
+        => $"{Condition.ExpressionStart} each {Iterator} in {Collection} {Condition.ExpressionEnd}";
+}

--- a/src/Sharpliner/AzureDevOps/EachExpression.cs
+++ b/src/Sharpliner/AzureDevOps/EachExpression.cs
@@ -8,13 +8,14 @@ public class EachExpression(string iterator, string collection)
     public string Collection { get; } = collection;
 
     public override string ToString()
-        => $"{Condition.ExpressionStart}{GetEachExpression(Iterator, Collection)}{Condition.ExpressionEnd}";
+        => GetEachExpression(Iterator, Collection);
 
     internal static string GetEachExpression(string iterator, string collection)
-        => $"each {iterator} in {collection}";
+        => $"{Condition.ExpressionStart}each {iterator} in {collection}{Condition.ExpressionEnd}";
 }
 
 public class EachBlock(string iterator, string collection) : IfCondition
 {
-    internal override string Serialize() => WrapTag(EachExpression.GetEachExpression(iterator, collection));
+    internal override string Serialize() => EachExpression.GetEachExpression(iterator, collection);
+    internal override string TagStart => ExpressionStart;
 }

--- a/src/Sharpliner/AzureDevOps/Model/ContainerResource.cs
+++ b/src/Sharpliner/AzureDevOps/Model/ContainerResource.cs
@@ -68,7 +68,6 @@ public record ContainerResource
     public ContainerResource(string identifier)
     {
         Identifier = identifier ?? throw new ArgumentNullException(nameof(identifier));
-        Pipeline.ValidateName(identifier);
     }
 }
 

--- a/src/Sharpliner/AzureDevOps/Model/JobBase.cs
+++ b/src/Sharpliner/AzureDevOps/Model/JobBase.cs
@@ -95,8 +95,6 @@ public abstract record JobBase : IDependsOn
 
     protected JobBase(string name, string? displayName = null)
     {
-        Pipeline.ValidateName(name);
-
         Name = name ?? throw new ArgumentNullException(nameof(name));
 
         if (displayName != null)

--- a/src/Sharpliner/AzureDevOps/Model/Step.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Step.cs
@@ -33,11 +33,6 @@ public abstract record Step
         get => _name;
         init
         {
-            if (value is not ConditionedParameterReference<string> && value.Definition is not null)
-            {
-                Pipeline.ValidateName(value.Definition);
-            }
-
             _name = value;
         }
     }

--- a/src/Sharpliner/AzureDevOps/Model/WebhookResource.cs
+++ b/src/Sharpliner/AzureDevOps/Model/WebhookResource.cs
@@ -32,7 +32,6 @@ public record WebhookResource
     public WebhookResource(string identifier)
     {
         Identifier = identifier ?? throw new System.ArgumentNullException(nameof(identifier));
-        Pipeline.ValidateName(Identifier);
     }
 }
 

--- a/src/Sharpliner/AzureDevOps/Pipeline.cs
+++ b/src/Sharpliner/AzureDevOps/Pipeline.cs
@@ -110,14 +110,6 @@ public record Pipeline : PipelineBase
         => Stages.GetStageValidations()
             .Append(new RepositoryCheckoutValidation(this))
             .ToList();
-
-    internal static void ValidateName(string name)
-    {
-        if (!AzureDevOpsDefinition.NameRegex.IsMatch(name))
-        {
-            throw new FormatException($"Invalid identifier '{name}'! Only A-Z, a-z, 0-9, and underscore are allowed.");
-        }
-    }
 }
 
 /// <summary>

--- a/tests/Sharpliner.Tests/AzureDevOps/ConditionedExpressions/EachExpressionTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/ConditionedExpressions/EachExpressionTests.cs
@@ -1,0 +1,66 @@
+﻿using System.Linq;
+using FluentAssertions;
+using Sharpliner.AzureDevOps;
+using Xunit;
+
+namespace Sharpliner.Tests.AzureDevOps.ConditionedExpressions;
+
+public class EachExpressionTests
+{
+    private class Each_Expression_Test_Pipeline : TestPipeline
+    {
+        public override Pipeline Pipeline => new()
+        {
+            Stages =
+            {
+                //Each("env", "parameters.environments")
+                //    .StageTemplate("../stages/provision.yml"), //, new()
+                    //{
+                //        { "environment", "${{ env }}" },
+                //        {
+                //            If.Equal("env.deploymentEnvironmentName", "''"), new TemplateParameters()
+                //            {
+                //                { "deploymentEnvironment", parameters["applicationName"] + " - env.name"  }
+                //            }
+                //        },
+                //        {
+                //            "${{ else }}",
+                //            // TODO: Else,
+                //            new TemplateParameters()
+                //            {
+                //                { "deploymentEnvironment", "env.deploymentEnvironmentName" }
+                //            }
+                //        },
+                //        { "regions", parameters["regions"] },
+                    //}),
+
+                If.IsBranch("main")
+                    .Each("env", "parameters.stages")
+                        .Stage(new Stage("stage-${{ env.name }}")
+                        {
+
+                        })
+                        .Stage(new Stage("stage2-${{ env.name }}")
+                        {
+
+                        }),
+            }
+        };
+    }
+
+    [Fact]
+    public void Each_Expression_Test()
+    {
+        var pipeline = new Each_Expression_Test_Pipeline();
+        var stageDef = pipeline.Pipeline.Stages.First();
+        pipeline.Serialize().Trim().Should().Be(
+            """
+            stages:
+            - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+                - ${{ each env in parameters.stages }}:
+                  - stage: stage-${{ env.name }}
+            
+                  - stage: stage2-${{ env.name }}
+            """);
+    }
+}

--- a/tests/Sharpliner.Tests/AzureDevOps/ConditionedExpressions/EachExpressionTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/ConditionedExpressions/EachExpressionTests.cs
@@ -13,26 +13,26 @@ public class EachExpressionTests
         {
             Stages =
             {
-                //Each("env", "parameters.environments")
-                //    .StageTemplate("../stages/provision.yml"), //, new()
-                    //{
-                //        { "environment", "${{ env }}" },
-                //        {
-                //            If.Equal("env.deploymentEnvironmentName", "''"), new TemplateParameters()
-                //            {
-                //                { "deploymentEnvironment", parameters["applicationName"] + " - env.name"  }
-                //            }
-                //        },
-                //        {
-                //            "${{ else }}",
-                //            // TODO: Else,
-                //            new TemplateParameters()
-                //            {
-                //                { "deploymentEnvironment", "env.deploymentEnvironmentName" }
-                //            }
-                //        },
-                //        { "regions", parameters["regions"] },
-                    //}),
+                Each("env", "parameters.environments")
+                    .StageTemplate("../stages/provision.yml", new()
+                    {
+                        { "environment", "${{ env }}" },
+                        {
+                            If.Equal("env.deploymentEnvironmentName", "''"), new TemplateParameters()
+                            {
+                                { "deploymentEnvironment", parameters["applicationName"] + " - env.name"  }
+                            }
+                        },
+                        {
+                            "${{ else }}",
+                            // TODO: Else,
+                            new TemplateParameters()
+                            {
+                                { "deploymentEnvironment", "env.deploymentEnvironmentName" }
+                            }
+                        },
+                        { "regions", parameters["regions"] },
+                    }),
 
                 If.IsBranch("main")
                     .Each("env", "parameters.stages")
@@ -52,15 +52,14 @@ public class EachExpressionTests
     public void Each_Expression_Test()
     {
         var pipeline = new Each_Expression_Test_Pipeline();
-        var stageDef = pipeline.Pipeline.Stages.First();
         pipeline.Serialize().Trim().Should().Be(
             """
             stages:
             - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-                - ${{ each env in parameters.stages }}:
-                  - stage: stage-${{ env.name }}
+              - ${{ each env in parameters.stages }}:
+                - stage: stage-${{ env.name }}
             
-                  - stage: stage2-${{ env.name }}
+                - stage: stage2-${{ env.name }}
             """);
     }
 }

--- a/tests/Sharpliner.Tests/AzureDevOps/ConditionedExpressions/EachExpressionTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/ConditionedExpressions/EachExpressionTests.cs
@@ -45,7 +45,7 @@ public class EachExpressionTests
                                 Each("foo", "bar")
                                     .Job(new Job("job-${{ foo }}"))
                                 .EndEach
-                                .If.IsBranch("main")
+                                .If.Equal("foo", "bar")
                                     .Job(new Job("job2-${{ foo }}"))
                             }
                         }),
@@ -79,7 +79,7 @@ public class EachExpressionTests
                   - ${{ each foo in bar }}:
                     - job: job-${{ foo }}
 
-                  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+                  - ${{ if eq('foo', 'bar') }}:
                     - job: job2-${{ foo }}
             """);
     }

--- a/tests/Sharpliner.Tests/PublicApiExport.txt
+++ b/tests/Sharpliner.Tests/PublicApiExport.txt
@@ -46,6 +46,7 @@
         protected static Sharpliner.AzureDevOps.DeploymentJob DeploymentJob(string jobName, string? displayName = null) { }
         protected static Sharpliner.AzureDevOps.Parameter DeploymentListParameter(string name, string? displayName = null, Sharpliner.AzureDevOps.ConditionedExpressions.ConditionedList<Sharpliner.AzureDevOps.DeploymentJob>? defaultValue = null) { }
         protected static Sharpliner.AzureDevOps.Parameter DeploymentParameter(string name, string? displayName = null, Sharpliner.AzureDevOps.DeploymentJob? defaultValue = null) { }
+        protected static Sharpliner.AzureDevOps.EachBlock Each(string iterator, string collection) { }
         protected static Sharpliner.AzureDevOps.InlineCondition EndsWith(Sharpliner.AzureDevOps.ConditionedExpressions.Arguments.InlineExpression needle, Sharpliner.AzureDevOps.ConditionedExpressions.Arguments.InlineExpression haystack) { }
         protected static Sharpliner.AzureDevOps.InlineCondition EndsWith<T>(Sharpliner.AzureDevOps.ConditionedExpressions.Arguments.InlineExpression needle, Sharpliner.AzureDevOps.ConditionedExpressions.Arguments.InlineExpression haystack) { }
         protected static Sharpliner.AzureDevOps.InlineCondition Equal(Sharpliner.AzureDevOps.ConditionedExpressions.Arguments.InlineExpression expression1, Sharpliner.AzureDevOps.ConditionedExpressions.Arguments.InlineExpression expression2) { }
@@ -185,6 +186,7 @@
     {
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.JobBase> DeploymentJob(this Sharpliner.AzureDevOps.IfCondition condition, Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.JobBase> job) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.JobBase> DeploymentJob(this Sharpliner.AzureDevOps.IfCondition condition, Sharpliner.AzureDevOps.JobBase job) { }
+        public static Sharpliner.AzureDevOps.IfCondition Each(this Sharpliner.AzureDevOps.IfCondition condition, string iterator, string collection) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.VariableBase> Group(this Sharpliner.AzureDevOps.IfCondition condition, string name) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.JobBase> Job(this Sharpliner.AzureDevOps.IfCondition condition, Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.JobBase> job) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.JobBase> Job(this Sharpliner.AzureDevOps.IfCondition condition, Sharpliner.AzureDevOps.JobBase job) { }
@@ -238,9 +240,9 @@
     }
     public static class ConditionedExtensions
     {
-        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.JobBase> DeploymentJob(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.JobBase> condition, Sharpliner.AzureDevOps.JobBase job) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.JobBase> DeploymentJob(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.JobBase> conditionedDefinition, Sharpliner.AzureDevOps.JobBase job) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.VariableBase> Group(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.VariableBase> conditionedDefinition, string name) { }
-        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.JobBase> Job(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.JobBase> condition, Sharpliner.AzureDevOps.JobBase job) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.JobBase> Job(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.JobBase> conditionedDefinition, Sharpliner.AzureDevOps.JobBase job) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.JobBase> JobLibrary(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.JobBase> conditionedDefinition, Sharpliner.AzureDevOps.JobLibrary library) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.JobBase> JobLibrary<T>(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.JobBase> conditionedDefinition)
             where T : Sharpliner.AzureDevOps.JobLibrary, new () { }
@@ -249,7 +251,7 @@
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Job> Jobs(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Job> conditionedDefinition, params Sharpliner.AzureDevOps.Job[] jobs) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Job> Jobs(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Job> conditionedDefinition, System.Collections.Generic.IEnumerable<Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Job>> jobs) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Job> Jobs(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Job> conditionedDefinition, System.Collections.Generic.IEnumerable<Sharpliner.AzureDevOps.Job> jobs) { }
-        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Stage> Stage(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Stage> condition, Sharpliner.AzureDevOps.Stage stage) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Stage> Stage(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Stage> conditionedDefinition, Sharpliner.AzureDevOps.Stage stage) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Stage> StageLibrary(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Stage> conditionedDefinition, Sharpliner.AzureDevOps.StageLibrary library) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Stage> StageLibrary<T>(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Stage> conditionedDefinition)
             where T : Sharpliner.AzureDevOps.StageLibrary, new () { }
@@ -258,7 +260,7 @@
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Stage> Stages(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Stage> conditionedDefinition, params Sharpliner.AzureDevOps.Stage[] stages) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Stage> Stages(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Stage> conditionedDefinition, System.Collections.Generic.IEnumerable<Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Stage>> stages) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Stage> Stages(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Stage> conditionedDefinition, System.Collections.Generic.IEnumerable<Sharpliner.AzureDevOps.Stage> stages) { }
-        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Step> Step(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Step> condition, Sharpliner.AzureDevOps.Step step) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Step> Step(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Step> conditionedDefinition, Sharpliner.AzureDevOps.Step step) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Step> StepLibrary(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Step> conditionedDefinition, Sharpliner.AzureDevOps.StepLibrary library) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Step> StepLibrary<T>(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Step> conditionedDefinition)
             where T : Sharpliner.AzureDevOps.StepLibrary, new () { }
@@ -353,6 +355,17 @@
         public void Read(YamlDotNet.Core.IParser parser, System.Type expectedType, YamlDotNet.Serialization.ObjectDeserializer nestedObjectDeserializer) { }
         public void Write(YamlDotNet.Core.IEmitter emitter, YamlDotNet.Serialization.ObjectSerializer nestedObjectSerializer) { }
         protected abstract void WriteCustomFields(YamlDotNet.Core.IEmitter emitter, YamlDotNet.Serialization.ObjectSerializer nestedObjectSerializer);
+    }
+    public class EachBlock : Sharpliner.AzureDevOps.IfCondition
+    {
+        public EachBlock(string iterator, string collection) { }
+    }
+    public class EachExpression
+    {
+        public EachExpression(string iterator, string collection) { }
+        public string Collection { get; }
+        public string Iterator { get; }
+        public override string ToString() { }
     }
     public class Environment : System.IEquatable<Sharpliner.AzureDevOps.Environment>
     {
@@ -1228,6 +1241,7 @@ namespace Sharpliner.AzureDevOps.ConditionedExpressions
         protected Conditioned(Sharpliner.AzureDevOps.IfCondition? condition) { }
         public Conditioned(T definition) { }
         public Sharpliner.AzureDevOps.IfCondition<T> Else { get; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<T> EndEach { get; }
         public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<T> EndIf { get; }
         public Sharpliner.AzureDevOps.ConditionedExpressions.IfConditionBuilder<T> If { get; }
         protected virtual void SerializeSelf(YamlDotNet.Core.IEmitter emitter, YamlDotNet.Serialization.ObjectSerializer nestedObjectSerializer) { }


### PR DESCRIPTION
Nested each blocks are not working yet but merging this to unblock a feature request

https://github.com/sharpliner/sharpliner/issues/281

