### PR TITLE
Allow template parameter reference everywhere

### DIFF
--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/Conditioned.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/Conditioned.cs
@@ -141,6 +141,9 @@ public record Conditioned<T> : Conditioned
     // Make sure we can for example assign a string into ConditionedDefinition<string>
     public static implicit operator Conditioned<T>(T value) => new(definition: value);
 
+    // Make sure we can assign ${{ parameters.name }} into conditioned
+    public static implicit operator Conditioned<T>(ParameterReference parameterRef) => new ConditionedParameterReference<T>(parameterRef);
+
     /// <summary>
     /// The actual definition (value).
     /// </summary>

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/ParameterReference.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/ParameterReference.cs
@@ -32,30 +32,6 @@ public class ParameterReference : IRuntimeExpression, ICompileTimeExpression, IY
     public void Write(IEmitter emitter, ObjectSerializer nestedObjectSerializer)
         => emitter.Emit(new Scalar(ToString()));
 
-    public static implicit operator Conditioned<int>(ParameterReference value) => new ConditionedParameterReference<int>(value);
-
-    public static implicit operator Conditioned<bool>(ParameterReference value) => new ConditionedParameterReference<bool>(value);
-
-    public static implicit operator Conditioned<string>(ParameterReference value) => new ConditionedParameterReference<string>(value);
-
-    public static implicit operator Conditioned<TimeSpan>(ParameterReference value) => new ConditionedParameterReference<TimeSpan>(value);
-
-    public static implicit operator Conditioned<TemplateParameters>(ParameterReference value) => new ConditionedParameterReference<TemplateParameters>(value);
-
-    public static implicit operator Conditioned<ConditionedDictionary>(ParameterReference value) => new ConditionedParameterReference<ConditionedDictionary>(value);
-
-    public static implicit operator Conditioned<InlineCondition>(ParameterReference value) => new ConditionedParameterReference<InlineCondition>(value);
-
-    public static implicit operator Conditioned<VariableBase>(ParameterReference value) => new ConditionedParameterReference<VariableBase>(value);
-
-    public static implicit operator Conditioned<Stage>(ParameterReference value) => new ConditionedParameterReference<Stage>(value);
-
-    public static implicit operator Conditioned<JobBase>(ParameterReference value) => new ConditionedParameterReference<JobBase>(value);
-
-    public static implicit operator Conditioned<Step>(ParameterReference value) => new ConditionedParameterReference<Step>(value);
-
-    public static implicit operator Conditioned<Pool>(ParameterReference value) => new ConditionedParameterReference<Pool>(value);
-
     public override bool Equals(object? obj)
     {
         if (obj is ParameterReference other)

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/CheckoutTask.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/CheckoutTask.cs
@@ -39,8 +39,7 @@ public abstract record CheckoutTask : Step
     /// Defaults to not checking out submodules.
     /// </summary>
     [YamlMember(Order = 103)]
-    [DefaultValue(SubmoduleCheckout.None)]
-    public SubmoduleCheckout Submodules { get; init; } = SubmoduleCheckout.None;
+    public Conditioned<SubmoduleCheckout>? Submodules { get; init; }
 
     /// <summary>
     /// Path to check out source code, relative to the agent's build directory (e.g. \_work\1).

--- a/src/Sharpliner/AzureDevOps/TemplateDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/TemplateDefinition.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Sharpliner.AzureDevOps.ConditionedExpressions;
+using Sharpliner.AzureDevOps.Tasks;
 using Sharpliner.Common;
 
 namespace Sharpliner.AzureDevOps;

--- a/tests/Sharpliner.Tests/AzureDevOps/ParameterReferenceTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/ParameterReferenceTests.cs
@@ -44,6 +44,11 @@ public class ParameterReferenceTests
                             Bash.Inline("curl -o $(Agent.TempDirectory)/sharpliner.zip") with
                             {
                                 ContinueOnError = parameters["continue"],
+                            },
+
+                            Checkout.Repository(parameters["repository"]) with
+                            {
+                                Submodules = parameters["submodules"]
                             }
                         }
                     },
@@ -94,6 +99,9 @@ public class ParameterReferenceTests
                 - bash: |-
                     curl -o $(Agent.TempDirectory)/sharpliner.zip
                   continueOnError: ${{ parameters.continue }}
+
+                - checkout: ${{ parameters.repository }}
+                  submodules: ${{ parameters.submodules }}
 
               - ${{ parameters.jobs }}
             - ${{ parameters.stages }}

--- a/tests/Sharpliner.Tests/PublicApiExport.txt
+++ b/tests/Sharpliner.Tests/PublicApiExport.txt
@@ -1286,6 +1286,7 @@ namespace Sharpliner.AzureDevOps.ConditionedExpressions
         protected virtual void SerializeSelf(YamlDotNet.Core.IEmitter emitter, YamlDotNet.Serialization.ObjectSerializer nestedObjectSerializer) { }
         public override string ToString() { }
         public override void Write(YamlDotNet.Core.IEmitter emitter, YamlDotNet.Serialization.ObjectSerializer nestedObjectSerializer) { }
+        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<T> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference parameterRef) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<T> op_Implicit(T value) { }
     }
     public class ElseCondition<T> : Sharpliner.AzureDevOps.IfCondition<T>
@@ -1434,18 +1435,6 @@ namespace Sharpliner.AzureDevOps.ConditionedExpressions
         public override string ToString() { }
         public void Write(YamlDotNet.Core.IEmitter emitter, YamlDotNet.Serialization.ObjectSerializer nestedObjectSerializer) { }
         public static string op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
-        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<int> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
-        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<bool> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
-        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
-        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<System.TimeSpan> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
-        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.TemplateParameters> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
-        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.ConditionedExpressions.ConditionedDictionary> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
-        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.InlineCondition> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
-        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.VariableBase> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
-        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Stage> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
-        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.JobBase> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
-        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Step> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
-        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Pool> op_Implicit(Sharpliner.AzureDevOps.ConditionedExpressions.ParameterReference value) { }
     }
     public class VariableReference : Sharpliner.AzureDevOps.ConditionedExpressions.Interfaces.ICompileTimeExpression, Sharpliner.AzureDevOps.ConditionedExpressions.Interfaces.IMacroExpression, Sharpliner.AzureDevOps.ConditionedExpressions.Interfaces.IRuntimeExpression, YamlDotNet.Serialization.IYamlConvertible
     {
@@ -1603,9 +1592,8 @@ namespace Sharpliner.AzureDevOps.Tasks
         public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string>? Path { get; init; }
         [YamlDotNet.Serialization.YamlMember(Order=105)]
         public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<bool>? PersistCredentials { get; init; }
-        [System.ComponentModel.DefaultValue(Sharpliner.AzureDevOps.Tasks.SubmoduleCheckout.None)]
         [YamlDotNet.Serialization.YamlMember(Order=103)]
-        public Sharpliner.AzureDevOps.Tasks.SubmoduleCheckout Submodules { get; init; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Tasks.SubmoduleCheckout>? Submodules { get; init; }
     }
     public class CheckoutTaskBuilder
     {


### PR DESCRIPTION
Allows to inject `${{ parameters.foo }}` into almost any place (all where we have `Conditioned<T>`)

#318