### PR TITLE
Update repo to .NET 9.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
 
     - uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 8.0.403
+        dotnet-version: 9.0.100
 
     - name: Build
       run: dotnet build src/Sharpliner/Sharpliner.csproj

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
 <Project>
 
   <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
   </PropertyGroup>

--- a/docs/AzureDevOps/GettingStarted.md
+++ b/docs/AzureDevOps/GettingStarted.md
@@ -23,10 +23,10 @@ Your file should look something like this:
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- .NET 5.0/6.0/7.0 are supported at the moment -->
-    <TargetFramework>net6.0</TargetFramework>
+    <!-- .NET 5.0+ are supported at the moment -->
+    <TargetFramework>net9.0</TargetFramework>
     <!-- Use C# 10+ for best experience with some of the definition syntax -->
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/PublicApiExporter/PublicApiExporter.csproj
+++ b/eng/PublicApiExporter/PublicApiExporter.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/Sharpliner.CI/Sharpliner.CI.csproj
+++ b/eng/Sharpliner.CI/Sharpliner.CI.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <EmbeddedResource Include="..\scripts\Get-Version.ps1" />
   </ItemGroup>

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -25,7 +25,7 @@ jobs:
   steps:
   - template: templates/install-dotnet-sdk.yml
     parameters:
-      version: 8.0.403
+      version: 9.0.100
 
   - powershell: |-
       New-Item -Path 'artifacts' -Name 'packages' -ItemType 'directory'

--- a/eng/pipelines/publish.yml
+++ b/eng/pipelines/publish.yml
@@ -25,7 +25,7 @@ jobs:
 
   - template: templates/install-dotnet-sdk.yml
     parameters:
-      version: 8.0.403
+      version: 9.0.100
 
   - powershell: |-
       New-Item -Path 'artifacts' -Name 'packages' -ItemType 'directory'

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.403",
+    "version": "9.0.100",
     "rollForward": "minor"
   }
 }

--- a/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Sharpliner.AzureDevOps.ConditionedExpressions;

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/Condition.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/Condition.cs
@@ -558,12 +558,12 @@ internal class IfOrCondition<T> : IfConjunctionCondition<T>
 internal class InlineXorCondition<T> : InlineConjunctionCondition<T>
 {
     internal InlineXorCondition(InlineCondition expression1, InlineCondition expression2)
-        : base("xor", new[] { expression1, expression2 })
+        : base("xor", [expression1, expression2])
     {
     }
 
     internal InlineXorCondition(string expression1, string expression2)
-        : base("xor", new[] { expression1, expression2 })
+        : base("xor", [expression1, expression2])
     {
     }
 }
@@ -571,12 +571,12 @@ internal class InlineXorCondition<T> : InlineConjunctionCondition<T>
 internal class IfXorCondition<T> : IfConjunctionCondition<T>
 {
     internal IfXorCondition(IfCondition expression1, IfCondition expression2)
-        : base("xor", new[] { expression1, expression2 })
+        : base("xor", [expression1, expression2])
     {
     }
 
     internal IfXorCondition(string expression1, string expression2)
-        : base("xor", new[] { expression1, expression2 })
+        : base("xor", [expression1, expression2])
     {
     }
 }

--- a/src/Sharpliner/AzureDevOps/Model/DeploymentJob.cs
+++ b/src/Sharpliner/AzureDevOps/Model/DeploymentJob.cs
@@ -13,8 +13,6 @@ namespace Sharpliner.AzureDevOps;
 /// </summary>
 public record DeploymentJob : JobBase
 {
-    private Conditioned<DeploymentStrategy>? _strategy;
-
     /// <summary>
     /// Name of the job (A-Z, a-z, 0-9, and underscore).
     /// </summary>
@@ -34,7 +32,7 @@ public record DeploymentJob : JobBase
     /// </summary>
     [YamlMember(Order = 1300)]
     [DisallowNull]
-    public Conditioned<DeploymentStrategy>? Strategy { get => _strategy; init => _strategy = value?.GetRoot(); }
+    public Conditioned<DeploymentStrategy>? Strategy { get; init => field = value?.GetRoot(); }
 
     /// <summary>
     /// A deployment job is a special type of job.

--- a/src/Sharpliner/AzureDevOps/Model/Job.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Job.cs
@@ -12,8 +12,6 @@ namespace Sharpliner.AzureDevOps;
 /// </summary>
 public record Job : JobBase
 {
-    private Conditioned<Strategy>? _strategy;
-
     /// <summary>
     /// Name of the job (A-Z, a-z, 0-9, and underscore).
     /// </summary>
@@ -26,7 +24,7 @@ public record Job : JobBase
     /// </summary>
     [YamlMember(Order = 400)]
     [DisallowNull]
-    public Conditioned<Strategy>? Strategy { get => _strategy; init => _strategy = value?.GetRoot(); }
+    public Conditioned<Strategy>? Strategy { get; init => field = value?.GetRoot(); }
 
     /// <summary>
     /// A step is a linear sequence of operations that make up a job

--- a/src/Sharpliner/AzureDevOps/Model/JobBase.cs
+++ b/src/Sharpliner/AzureDevOps/Model/JobBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using Sharpliner.AzureDevOps.ConditionedExpressions;
 using YamlDotNet.Serialization;
@@ -12,9 +11,6 @@ namespace Sharpliner.AzureDevOps;
 /// </summary>
 public abstract record JobBase : IDependsOn
 {
-    private Conditioned<Pool>? _pool;
-    private Conditioned<ContainerReference>? _container;
-
     /// <summary>
     /// The name of the job.
     /// </summary>
@@ -39,14 +35,14 @@ public abstract record JobBase : IDependsOn
     /// A pool specification also holds information about the job's strategy for running.
     /// </summary>
     [YamlMember(Order = 300)]
-    public Conditioned<Pool>? Pool { get => _pool; init => _pool = value?.GetRoot(); }
+    public Conditioned<Pool>? Pool { get; init => field = value?.GetRoot(); }
 
     /// <summary>
     /// Container to run this job inside of.
     /// </summary>
     [YamlMember(Order = 500)]
     [DisallowNull]
-    public Conditioned<ContainerReference>? Container { get => _container; init => _container = value?.GetRoot(); }
+    public Conditioned<ContainerReference>? Container { get; init => field = value?.GetRoot(); }
 
     /// <summary>
     /// Specifies variables at the job level

--- a/src/Sharpliner/AzureDevOps/Model/LifeCycleHook.cs
+++ b/src/Sharpliner/AzureDevOps/Model/LifeCycleHook.cs
@@ -8,14 +8,12 @@ namespace Sharpliner.AzureDevOps;
 /// </summary>
 public record LifeCycleHook
 {
-    private Conditioned<Pool>? _pool;
-
     /// <summary>
     /// Specifies which pool to use for a job of the pipeline
     /// A pool specification also holds information about the job's strategy for running.
     /// </summary>
     [YamlMember(Order = 300)]
-    public Conditioned<Pool>? Pool { get => _pool; set => _pool = value?.GetRoot(); }
+    public Conditioned<Pool>? Pool { get; set => field = value?.GetRoot(); }
 
     /// <summary>
     /// A step is a linear sequence of operations that make up a job

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/AzureDevOpsTask.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/AzureDevOpsTask.cs
@@ -10,8 +10,6 @@ namespace Sharpliner.AzureDevOps.Tasks;
 /// </summary>
 public record AzureDevOpsTask : Step
 {
-    private readonly TaskInputs _inputs = [];
-
     /// <summary>
     /// Task name in the form 'PublishTestResults@2'.
     /// </summary>
@@ -24,7 +22,7 @@ public record AzureDevOpsTask : Step
     [YamlMember(Order = 101)]
     public TaskInputs Inputs
     {
-        get => _inputs;
+        get;
         init
         {
             // Add inputs to the existing ones
@@ -32,15 +30,15 @@ public record AzureDevOpsTask : Step
             {
                 if (value == null)
                 {
-                    _inputs.Remove(item.Key);
+                    field.Remove(item.Key);
                 }
                 else
                 {
-                    _inputs[item.Key] = item.Value;
+                    field[item.Key] = item.Value;
                 }
             }
         }
-    }
+    } = [];
 
     /// <summary>
     /// Number of retries if the task fails.

--- a/src/Sharpliner/AzureDevOps/Pipeline.cs
+++ b/src/Sharpliner/AzureDevOps/Pipeline.cs
@@ -14,9 +14,6 @@ namespace Sharpliner.AzureDevOps;
 /// </summary>
 public abstract record PipelineBase
 {
-    private Conditioned<Pool>? _pool;
-    private Conditioned<Resources>? _resources;
-
     /// <summary>
     /// Name of the pipeline in the build numbering format
     /// More details can be found in <see href="https://docs.microsoft.com/en-us/azure/devops/pipelines/process/run-number?view=azure-devops&amp;tabs=yaml">official Azure DevOps pipelines documentation</see>.
@@ -74,7 +71,7 @@ public abstract record PipelineBase
     /// </summary>
     [YamlMember(Order = 400)]
     [DisallowNull]
-    public Conditioned<Resources>? Resources { get => _resources; init => _resources = value?.GetRoot(); }
+    public Conditioned<Resources>? Resources { get; init => field = value?.GetRoot(); }
 
     /// <summary>
     /// Specifies variables at the pipeline level
@@ -88,7 +85,7 @@ public abstract record PipelineBase
     /// A pool specification also holds information about the job's strategy for running.
     /// </summary>
     [YamlMember(Order = 550)]
-    public Conditioned<Pool>? Pool { get => _pool; init => _pool = value?.GetRoot(); }
+    public Conditioned<Pool>? Pool { get; init => field = value?.GetRoot(); }
 
     /// <summary>
     /// Returns the list of validations that should be run on the definition (e.g. wrong dependsOn, artifact name typos..).
@@ -110,10 +107,11 @@ public record Pipeline : PipelineBase
     public ConditionedList<Stage> Stages { get; init; } = [];
 
     /// <inheritdoc/>
-    public override IReadOnlyCollection<IDefinitionValidation> Validations
-        => Stages.GetStageValidations()
-            .Append(new RepositoryCheckoutValidation(this))
-            .ToList();
+    public override IReadOnlyCollection<IDefinitionValidation> Validations =>
+    [
+        .. Stages.GetStageValidations(),
+        new RepositoryCheckoutValidation(this)
+    ];
 }
 
 /// <summary>
@@ -150,8 +148,9 @@ public record SingleStagePipeline : PipelineBase
     public ConditionedList<JobBase> Jobs { get; init; } = [];
 
     /// <inheritdoc/>
-    public override IReadOnlyCollection<IDefinitionValidation> Validations
-        => Jobs.GetJobValidations()
-            .Append(new RepositoryCheckoutValidation(this))
-            .ToList();
+    public override IReadOnlyCollection<IDefinitionValidation> Validations=>
+    [
+        .. Jobs.GetJobValidations(),
+        new RepositoryCheckoutValidation(this)
+    ];
 }

--- a/src/Sharpliner/Common/IDefinitionValidation.cs
+++ b/src/Sharpliner/Common/IDefinitionValidation.cs
@@ -48,26 +48,20 @@ public enum ValidationSeverity
 /// <summary>
 /// Represents a validation error with a severity and message.
 /// </summary>
-public class ValidationError
+/// <remarks>
+/// Initializes a new instance of the <see cref="ValidationError"/> class with the specified severity and message.
+/// </remarks>
+/// <param name="severity">The severity of the validation error.</param>
+/// <param name="message">The message of the validation error.</param>
+public class ValidationError(ValidationSeverity severity, string message)
 {
     /// <summary>
     /// Gets the severity of the validation error.
     /// </summary>
-    public ValidationSeverity Severity { get; }
+    public ValidationSeverity Severity { get; } = severity;
 
     /// <summary>
     /// Gets the message of the validation error.
     /// </summary>
-    public string Message { get; }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ValidationError"/> class with the specified severity and message.
-    /// </summary>
-    /// <param name="severity">The severity of the validation error.</param>
-    /// <param name="message">The message of the validation error.</param>
-    public ValidationError(ValidationSeverity severity, string message)
-    {
-        Severity = severity;
-        Message = message;
-    }
+    public string Message { get; } = message;
 }

--- a/src/Sharpliner/GlobalSuppressions.cs
+++ b/src/Sharpliner/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Style", "IDE0130:Namespace does not match folder structure", Justification = "<Pending>", Scope = "namespaceanddescendants", Target = "~N:Sharpliner")]

--- a/src/Sharpliner/Sharpliner.csproj
+++ b/src/Sharpliner/Sharpliner.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
 
     <!-- NuGet details -->
     <RepositoryType>git</RepositoryType>
@@ -71,6 +71,12 @@
         <Visible>false</Visible>
         <BuildAction>Content</BuildAction>
       </_PackageFiles>
+
+      <_PackageFiles Include="$(OutputPath)\net9.0\YamlDotNet.dll">
+        <PackagePath>lib\net9.0</PackagePath>
+        <Visible>false</Visible>
+        <BuildAction>Content</BuildAction>
+      </_PackageFiles>
     </ItemGroup>
 
     <ItemGroup>
@@ -88,6 +94,12 @@
 
       <_PackageFiles Include="$(OutputPath)\net8.0\OneOf.dll">
         <PackagePath>lib\net8.0</PackagePath>
+        <Visible>false</Visible>
+        <BuildAction>Content</BuildAction>
+      </_PackageFiles>
+
+      <_PackageFiles Include="$(OutputPath)\net9.0\OneOf.dll">
+        <PackagePath>lib\net9.0</PackagePath>
         <Visible>false</Visible>
         <BuildAction>Content</BuildAction>
       </_PackageFiles>

--- a/src/Sharpliner/Sharpliner.csproj
+++ b/src/Sharpliner/Sharpliner.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework></TargetFramework>
     <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
 
     <!-- NuGet details -->

--- a/src/Sharpliner/SharplinerPublisher.cs
+++ b/src/Sharpliner/SharplinerPublisher.cs
@@ -39,13 +39,13 @@ public class SharplinerPublisher(TaskLoggingHelper logger)
 
         LoadConfiguration(assembly);
 
-        foreach (ISharplinerDefinition definition in FindAllImplementations<ISharplinerDefinition>(assembly))
+        foreach (ISharplinerDefinition definition in SharplinerPublisher.FindAllImplementations<ISharplinerDefinition>(assembly))
         {
             definitionFound = true;
             PublishDefinition(definition, failIfChanged);
         }
 
-        foreach ((ISharplinerDefinition definition, Type collection) in FindDefinitionsInCollections(assembly))
+        foreach ((ISharplinerDefinition definition, Type collection) in SharplinerPublisher.FindDefinitionsInCollections(assembly))
         {
             definitionFound = true;
             PublishDefinition(definition, failIfChanged, collection);
@@ -70,7 +70,7 @@ public class SharplinerPublisher(TaskLoggingHelper logger)
     /// <param name="collection">Type of the collection the definition is coming from (if it is)</param>
     private void PublishDefinition(ISharplinerDefinition definition, bool failIfChanged, Type? collection = null)
     {
-        var path = GetDestinationPath(definition);
+        var path = SharplinerPublisher.GetDestinationPath(definition);
 
         var typeName = collection == null ? definition.GetType().Name : collection.Name;
 
@@ -141,11 +141,11 @@ public class SharplinerPublisher(TaskLoggingHelper logger)
         }
     }
 
-    private IEnumerable<(ISharplinerDefinition Definition, Type Collection)> FindDefinitionsInCollections(Assembly assembly) =>
+    private static IEnumerable<(ISharplinerDefinition Definition, Type Collection)> FindDefinitionsInCollections(Assembly assembly) =>
         FindAllImplementations<ISharplinerDefinitionCollection>(assembly)
             .SelectMany(collection => collection.Definitions.Select(definition => (definition, collection.GetType())));
 
-    private List<T> FindAllImplementations<T>(Assembly assembly)
+    private static List<T> FindAllImplementations<T>(Assembly assembly)
     {
         var pipelines = new List<T>();
         var typeToFind = typeof(T);
@@ -163,7 +163,7 @@ public class SharplinerPublisher(TaskLoggingHelper logger)
 
     private void LoadConfiguration(Assembly assembly)
     {
-        var configurations = FindAllImplementations<SharplinerConfiguration>(assembly);
+        var configurations = SharplinerPublisher.FindAllImplementations<SharplinerConfiguration>(assembly);
 
         if (configurations.Count > 1)
         {
@@ -180,7 +180,7 @@ public class SharplinerPublisher(TaskLoggingHelper logger)
     /// <summary>
     /// Gets the path where YAML of this definition should be published to
     /// </summary>
-    private string GetDestinationPath(ISharplinerDefinition definition)
+    private static string GetDestinationPath(ISharplinerDefinition definition)
     {
         switch (definition.TargetPathType)
         {

--- a/tests/E2E.Tests/ProjectUsingTheLibrary/E2E.Tests.ProjectUsingTheLibrary.csproj
+++ b/tests/E2E.Tests/ProjectUsingTheLibrary/E2E.Tests.ProjectUsingTheLibrary.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tests/E2E.Tests/ProjectUsingTheLibrary/ProjectTestDefinition.cs
+++ b/tests/E2E.Tests/ProjectUsingTheLibrary/ProjectTestDefinition.cs
@@ -1,7 +1,7 @@
 using E2E.Tests.SharplinerLibrary;
 using Sharpliner;
 
-namespace Tests.ProjectUsingTheLibraryNuGet;
+namespace E2E.Tests.ProjectUsingTheLibrary;
 
 // These NuGet.Tests are E2E testing following scenario:
 // 1. We create a "library" project with an arbitrary Sharpliner definition

--- a/tests/E2E.Tests/ProjectUsingTheLibraryNuGet/E2E.Tests.ProjectUsingTheLibraryNuGet.csproj
+++ b/tests/E2E.Tests/ProjectUsingTheLibraryNuGet/E2E.Tests.ProjectUsingTheLibraryNuGet.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tests/E2E.Tests/ProjectUsingTheLibraryNuGet/NuGetTestDefinition.cs
+++ b/tests/E2E.Tests/ProjectUsingTheLibraryNuGet/NuGetTestDefinition.cs
@@ -1,7 +1,7 @@
 using E2E.Tests.SharplinerLibrary;
 using Sharpliner;
 
-namespace Tests.ProjectUsingTheLibraryNuGet;
+namespace E2E.Tests.ProjectUsingTheLibraryNuGet;
 
 // These NuGet.Tests are E2E testing following scenario:
 // 1. We create a "library" project with an arbitrary Sharpliner definition

--- a/tests/E2E.Tests/SharplinerLibrary/E2E.Tests.SharplinerLibrary.csproj
+++ b/tests/E2E.Tests/SharplinerLibrary/E2E.Tests.SharplinerLibrary.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tests/Sharpliner.Tests/AzureDevOps/Model/VariableSerializationTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/Model/VariableSerializationTests.cs
@@ -8,13 +8,13 @@ public class VariableSerializationTests
 {
     private class VariablesPipeline : TestPipeline
     {
-        private static readonly Variable s_ConfigurationVariable = new Variable("Configuration", "Release"); // We can create the objects and then reuse them for definition too
+        private static readonly Variable s_configurationVariable = new("Configuration", "Release"); // We can create the objects and then reuse them for definition too
 
         public override Pipeline Pipeline => new()
         {
             Variables =
             {
-                s_ConfigurationVariable,
+                s_configurationVariable,
                 Variable("Framework", "net8.0"),     // Or we have this more YAML-like definition
                 Group("PR keyvault variables"),
 
@@ -22,7 +22,7 @@ public class VariableSerializationTests
                     .Variable("TargetBranch", variables.System.PullRequest.SourceBranch)
                     .Variable("IsPr", true),
 
-                If.And(IsBranch("production"), NotEqual(s_ConfigurationVariable, "Debug"))
+                If.And(IsBranch("production"), NotEqual(s_configurationVariable, "Debug"))
                     .Variables(("PublishProfileFile", "Prod"), ("foo", "bar"))
                     .If.IsNotPullRequest
                         .Variable("AzureSubscription", "Int")

--- a/tests/Sharpliner.Tests/GlobalSuppressions.cs
+++ b/tests/Sharpliner.Tests/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Style", "IDE0130:Namespace does not match folder structure", Justification = "<Pending>", Scope = "namespaceanddescendants", Target = "~N:Sharpliner.Tests")]

--- a/tests/Sharpliner.Tests/Sharpliner.Tests.csproj
+++ b/tests/Sharpliner.Tests/Sharpliner.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
Adds the 9.0 target and also gets rid of most of the compiler messages.
The SDK version is now read from `global.json` file and inserted to YAML from there.