### PR TITLE
feature: remove confusing Template method

### DIFF
--- a/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
@@ -241,12 +241,6 @@ public abstract class AzureDevOpsDefinition
     /// <param name="name">Group name</param>
     protected static Conditioned<VariableBase> Group(string name) => new(new VariableGroup(name));
 
-    /// <summary>
-    /// References a variable template.
-    /// </summary>
-    /// <param name="name">Template name</param>
-    protected static Conditioned<VariableBase> Template(string name) => new(new VariableTemplate(name));
-
     #endregion
 
     #region Pipeline task shorthands

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/ConditionExtensions.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/ConditionExtensions.cs
@@ -77,12 +77,6 @@ public static class ConditionExtensions
         => Conditioned.Link<VariableBase>(condition, new VariableGroup(name));
 
     /// <summary>
-    /// References a variable template.
-    /// </summary>
-    public static Conditioned<VariableBase> Template(this IfCondition condition, string name)
-        => Conditioned.Link<VariableBase>(condition, new VariableTemplate(name));
-
-    /// <summary>
     /// Creates a new stage.
     /// </summary>
     public static Conditioned<Stage> Stage(this IfCondition condition, Stage stage)

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/ConditionedExtensions.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/ConditionedExtensions.cs
@@ -91,17 +91,6 @@ public static class ConditionedExtensions
     }
 
     /// <summary>
-    /// References a variable template.
-    /// </summary>
-    public static Conditioned<VariableBase> Template(
-        this Conditioned<VariableBase> conditionedDefinition,
-        string name)
-    {
-        conditionedDefinition.Definitions.Add(new Conditioned<VariableBase>(definition: new VariableTemplate(name)));
-        return conditionedDefinition;
-    }
-
-    /// <summary>
     /// Creates a new stage.
     /// </summary>
     public static Conditioned<Stage> Stage(this Conditioned<Stage> conditionedDefinition, Stage stage)

--- a/src/Sharpliner/AzureDevOps/Model/VariableDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/Model/VariableDefinition.cs
@@ -40,34 +40,6 @@ public record VariableGroup : VariableBase
 
 /// <summary>
 /// <para>
-/// A template for a variable that can be referenced in Azure DevOps pipelines. See <see href="https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/variables-template"/>
-/// </para>
-/// For example:
-/// <code>
-/// - template: variables/build.yml
-/// </code>
-/// </summary>
-public record VariableTemplate : VariableBase
-{
-    /// <summary>
-    /// The path to the template file.
-    /// </summary>
-    [YamlMember(Alias = "template")]
-    public Conditioned<string> Name { get; }
-
-    /// <summary>
-    /// Creates a new instance of <see cref="VariableTemplate"/>.
-    /// </summary>
-    /// <param name="name">The path to the template</param>
-    /// <exception cref="ArgumentNullException">If the input is null</exception>
-    public VariableTemplate(string name)
-    {
-        Name = name ?? throw new ArgumentNullException(nameof(name));
-    }
-}
-
-/// <summary>
-/// <para>
 /// Define variables using name/value pairs that can be referenced in Azure DevOps pipelines. See <see href="https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/variables"/>
 /// </para>
 /// For example:

--- a/tests/Sharpliner.Tests/AzureDevOps/ConditionedExpressions/ConditionalsTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/ConditionedExpressions/ConditionalsTests.cs
@@ -80,10 +80,18 @@ public class ConditionalsTests
                     .Variable("legacy", true)
                 .EndIf
                 .If.IsBranch("patch-1")
+                    .VariableTemplate("patch-template.yml", new()
+                    {
+                        ["target"] = "patch-branch"
+                    })
                     .Variable("fast", true),
                 If.And(IsPullRequest, IsNotBranch("main"))
-                    .Group("pr-group"),
-            }
+                    .Group("pr-group")
+                    .VariableTemplate("pr-template.yml", new()
+                    {
+                        ["target"] = "pr-branch"
+                    }),
+            },
         };
     }
 
@@ -103,11 +111,19 @@ public class ConditionalsTests
                 value: true
 
             - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/patch-1') }}:
+              - template: patch-template.yml
+                parameters:
+                  target: patch-branch
+
               - name: fast
                 value: true
 
             - ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
               - group: pr-group
+
+              - template: pr-template.yml
+                parameters:
+                  target: pr-branch
             """);
     }
 

--- a/tests/Sharpliner.Tests/AzureDevOps/PipelineVariableTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/PipelineVariableTests.cs
@@ -14,8 +14,8 @@ public class PipelineVariableTests
             {
                 Variable("SomeVariable", "Some Value"),
                 Group("SomeGroup"),
-                Template("SomeTemplate")
-            }
+                VariableTemplate("SomeTemplate")
+            },
         };
     }
 

--- a/tests/Sharpliner.Tests/PublicApiExport.txt
+++ b/tests/Sharpliner.Tests/PublicApiExport.txt
@@ -113,7 +113,6 @@ namespace Sharpliner.AzureDevOps
         protected static Sharpliner.AzureDevOps.Template<Sharpliner.AzureDevOps.Step> StepTemplate(string path, Sharpliner.AzureDevOps.TemplateParameters? parameters = null) { }
         protected static Sharpliner.AzureDevOps.Parameter StringParameter(string name, string? displayName = null, string? defaultValue = null, System.Collections.Generic.IEnumerable<string>? allowedValues = null) { }
         protected static Sharpliner.AzureDevOps.Tasks.AzureDevOpsTask Task(string taskName, string? displayName = null) { }
-        protected static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.VariableBase> Template(string name) { }
         protected static Sharpliner.AzureDevOps.Step ValidateYamlsArePublished(string pipelineProject) { }
         protected static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.VariableBase> Variable(string name, bool value) { }
         protected static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.VariableBase> Variable(string name, int value) { }
@@ -222,7 +221,6 @@ namespace Sharpliner.AzureDevOps
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Step> Steps(this Sharpliner.AzureDevOps.IfCondition condition, System.Collections.Generic.IEnumerable<Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Step>> steps) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Step> Steps(this Sharpliner.AzureDevOps.IfCondition condition, System.Collections.Generic.IEnumerable<Sharpliner.AzureDevOps.Step> steps) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Strategy> Strategy(this Sharpliner.AzureDevOps.IfCondition condition, Sharpliner.AzureDevOps.Strategy strategy) { }
-        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.VariableBase> Template(this Sharpliner.AzureDevOps.IfCondition condition, string name) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<T> Value<T>(this Sharpliner.AzureDevOps.IfCondition condition, T value) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.VariableBase> Variable(this Sharpliner.AzureDevOps.IfCondition condition, Sharpliner.AzureDevOps.Variable variable) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.VariableBase> Variable(this Sharpliner.AzureDevOps.IfCondition condition, string name, bool value) { }
@@ -271,7 +269,6 @@ namespace Sharpliner.AzureDevOps
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Step> Steps(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Step> conditionedDefinition, params Sharpliner.AzureDevOps.Step[] steps) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Step> Steps(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Step> conditionedDefinition, System.Collections.Generic.IEnumerable<Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Step>> steps) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Step> Steps(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.Step> conditionedDefinition, System.Collections.Generic.IEnumerable<Sharpliner.AzureDevOps.Step> steps) { }
-        public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.VariableBase> Template(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.VariableBase> conditionedDefinition, string name) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.VariableBase> Variable(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.VariableBase> conditionedDefinition, string name, bool value) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.VariableBase> Variable(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.VariableBase> conditionedDefinition, string name, int value) { }
         public static Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.VariableBase> Variable(this Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<Sharpliner.AzureDevOps.VariableBase> conditionedDefinition, string name, string value) { }
@@ -1122,12 +1119,6 @@ namespace Sharpliner.AzureDevOps
         public Sharpliner.AzureDevOps.ConditionedExpressions.VariableReference this[string variableName] { get; }
         protected abstract string Prefix { get; }
         protected Sharpliner.AzureDevOps.ConditionedExpressions.VariableReference GetReference(string name) { }
-    }
-    public class VariableTemplate : Sharpliner.AzureDevOps.VariableBase, System.IEquatable<Sharpliner.AzureDevOps.VariableTemplate>
-    {
-        public VariableTemplate(string name) { }
-        [YamlDotNet.Serialization.YamlMember(Alias="template")]
-        public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<string> Name { get; }
     }
     public abstract class VariableTemplateCollection : Sharpliner.AzureDevOps.TemplateDefinitionCollection<Sharpliner.AzureDevOps.VariableBase>
     {


### PR DESCRIPTION
closes #370

this is already supported by the `VariableTemplate` utility method, which follows the convension of the other template methods such as `StageTemplate`, `JobTemplate`, `StepTemplate`