### PR TITLE
bugfix: make extends property appear last in pipelines

### DIFF
--- a/src/Sharpliner/AzureDevOps/Pipeline.cs
+++ b/src/Sharpliner/AzureDevOps/Pipeline.cs
@@ -123,7 +123,7 @@ public record PipelineWithExtends : PipelineBase
     /// <summary>
     /// Specifies the template that this pipeline extends.
     /// </summary>
-    [YamlMember(Order = 90)]
+    [YamlMember(Order = 600)]
     [DisallowNull]
 #if NET8_0_OR_GREATER
     public required Extends Extends { get; init; }

--- a/tests/Sharpliner.Tests/AzureDevOps/ExtendedPipelineTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/ExtendedPipelineTests.cs
@@ -12,14 +12,16 @@ public class ExtendedPipelineTests
 
         public override PipelineWithExtends Pipeline => new()
         {
-            Extends = new("templates/pipeline-template.yml")
+            Variables = 
+            [
+                Variable("key1", "value1"),
+            ],
+            Extends = new("templates/pipeline-template.yml", new()
             {
-                Parameters = new()
-                {
-                    { "param1", "value1" },
-                    { "param2", false },
-                }
-            },
+                ["param1"] = "value1",
+                ["param2"] = false,
+                ["param3"] = variables["key1"], // TODO: see https://github.com/sharpliner/sharpliner/issues/375
+            }),
 
             Trigger = Trigger.None,
             Pool = new HostedPool(vmImage: "ubuntu-latest"),
@@ -35,6 +37,10 @@ public class ExtendedPipelineTests
             """
             trigger: none
 
+            variables:
+            - name: key1
+              value: value1
+
             pool:
               vmImage: ubuntu-latest
 
@@ -43,6 +49,7 @@ public class ExtendedPipelineTests
               parameters:
                 param1: value1
                 param2: false
+                param3: $(key1)
             """);
     }
 }

--- a/tests/Sharpliner.Tests/AzureDevOps/ExtendedPipelineTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/ExtendedPipelineTests.cs
@@ -33,16 +33,16 @@ public class ExtendedPipelineTests
 
         yaml.Trim().Should().Be(
             """
+            trigger: none
+
+            pool:
+              vmImage: ubuntu-latest
+
             extends:
               template: templates/pipeline-template.yml
               parameters:
                 param1: value1
                 param2: false
-
-            trigger: none
-
-            pool:
-              vmImage: ubuntu-latest
             """);
     }
 }

--- a/tests/Sharpliner.Tests/PublicApiExport.txt
+++ b/tests/Sharpliner.Tests/PublicApiExport.txt
@@ -751,7 +751,7 @@ namespace Sharpliner.AzureDevOps
         public PipelineWithExtends() { }
         public override System.Collections.Generic.IReadOnlyCollection<Sharpliner.Common.IDefinitionValidation> Validations { get; }
         [System.Runtime.CompilerServices.RequiredMember]
-        [YamlDotNet.Serialization.YamlMember(Order=90)]
+        [YamlDotNet.Serialization.YamlMember(Order=600)]
         public Sharpliner.AzureDevOps.Extends Extends { get; init; }
     }
     public class Pool : System.IEquatable<Sharpliner.AzureDevOps.Pool>


### PR DESCRIPTION
when passing variables to the extends-template parameters, the extends property must be defined after the variables.

![image](https://github.com/user-attachments/assets/746db6a7-cc5d-4400-a2ca-d965f77cc902)
