### PR TITLE
feature: create a public API for SharplinerSerializer

### DIFF
--- a/src/Sharpliner/SharplinerSerializer.cs
+++ b/src/Sharpliner/SharplinerSerializer.cs
@@ -5,15 +5,17 @@ using YamlDotNet.Serialization.NamingConventions;
 
 namespace Sharpliner;
 
-internal static class SharplinerSerializer
+public static class SharplinerSerializer
 {
-    public static ISerializer Serializer { get; } = InitializeSerializer();
+    internal static ISerializer Serializer { get; } = InitializeSerializer();
 
-    public static string Serialize(object data)
+    public static string Serialize(object data, ISharplinerConfiguration configuration)
     {
         var yaml = Serializer.Serialize(data);
-        return SharplinerConfiguration.Current.Serialization.PrettifyYaml ? Prettify(yaml) : yaml;
+        return configuration.Serialization.PrettifyYaml ? Prettify(yaml) : yaml;
     }
+
+    internal static string Serialize(object data) => Serialize(data, SharplinerConfiguration.Current);
 
     private static ISerializer InitializeSerializer()
     {
@@ -26,7 +28,7 @@ internal static class SharplinerSerializer
         return serializerBuilder.Build();
     }
 
-    public static string Prettify(string yaml)
+    internal static string Prettify(string yaml)
     {
         // Add empty new lines to make text more readable
         var newLineReplace = Environment.NewLine + "$1";

--- a/src/Sharpliner/SharplinerSerializer.cs
+++ b/src/Sharpliner/SharplinerSerializer.cs
@@ -5,17 +5,25 @@ using YamlDotNet.Serialization.NamingConventions;
 
 namespace Sharpliner;
 
+/// <summary>
+/// Serializer for Sharpliner objects.
+/// </summary>
 public static class SharplinerSerializer
 {
     internal static ISerializer Serializer { get; } = InitializeSerializer();
 
-    public static string Serialize(object data, ISharplinerConfiguration configuration)
+    /// <summary>
+    /// Serializes the given object to a YAML string. Can be used with <see cref="AzureDevOps.PipelineBase"/>
+    /// </summary>
+    /// <param name="data">The object to serialize</param>
+    /// <param name="configuration">The configuration to use for serialization</param>
+    /// <returns>The serialized YAML string</returns>
+    public static string Serialize(object data, ISharplinerConfiguration? configuration = null)
     {
         var yaml = Serializer.Serialize(data);
+        configuration ??= SharplinerConfiguration.Current;
         return configuration.Serialization.PrettifyYaml ? Prettify(yaml) : yaml;
     }
-
-    internal static string Serialize(object data) => Serialize(data, SharplinerConfiguration.Current);
 
     private static ISerializer InitializeSerializer()
     {

--- a/src/Sharpliner/SharplinerSerializer.cs
+++ b/src/Sharpliner/SharplinerSerializer.cs
@@ -16,7 +16,7 @@ public static class SharplinerSerializer
     /// Serializes the given object to a YAML string. Can be used with <see cref="AzureDevOps.PipelineBase"/>
     /// </summary>
     /// <param name="data">The object to serialize</param>
-    /// <param name="configuration">The configuration to use for serialization</param>
+    /// <param name="configuration">The optional configuration to use for serialization</param>
     /// <returns>The serialized YAML string</returns>
     public static string Serialize(object data, ISharplinerConfiguration? configuration = null)
     {

--- a/tests/Sharpliner.Tests/PublicApiExport.txt.verified.txt
+++ b/tests/Sharpliner.Tests/PublicApiExport.txt.verified.txt
@@ -2282,6 +2282,10 @@ namespace Sharpliner
         public bool Publish(string assemblyPath, bool failIfChanged) { }
         public static string[] GetDefaultHeader(System.Type type) { }
     }
+    public static class SharplinerSerializer
+    {
+        public static string Serialize(object data, Sharpliner.ISharplinerConfiguration configuration) { }
+    }
     public enum TargetPathType
     {
         RelativeToGitRoot = 0,

--- a/tests/Sharpliner.Tests/PublicApiExport.txt.verified.txt
+++ b/tests/Sharpliner.Tests/PublicApiExport.txt.verified.txt
@@ -2284,7 +2284,7 @@ namespace Sharpliner
     }
     public static class SharplinerSerializer
     {
-        public static string Serialize(object data, Sharpliner.ISharplinerConfiguration configuration) { }
+        public static string Serialize(object data, Sharpliner.ISharplinerConfiguration? configuration = null) { }
     }
     public enum TargetPathType
     {


### PR DESCRIPTION
when not using msbuild and the `SharplinerPublisher` entry-point for file generation we need a public API for serializing classes that extend from `PipelineBase`

FYI @trevorlacey-msft