### PR TITLE
feature: skip dotnet build command when skipping publish definitions

### DIFF
--- a/src/Sharpliner/PublishDefinitions.cs
+++ b/src/Sharpliner/PublishDefinitions.cs
@@ -23,21 +23,10 @@ public class PublishDefinitions : Microsoft.Build.Utilities.Task
     public bool FailIfChanged { get; set; }
 
     /// <summary>
-    /// Skip the publishing of YAMLs.
-    /// </summary>
-    public bool Skip { get; set; }
-
-    /// <summary>
     /// This method finds all pipeline definitions via reflection and publishes them to YAML.
     /// </summary>
     public override bool Execute()
     {
-        if (Skip)
-        {
-            Log.LogMessage(MessageImportance.High, "Skipping the publishing of YAMLs");
-            return true;
-        }
-
         // PLEASE READ
         // This method loads and executes the Sharpliner publisher class BUT in the LoadFrom context.
         // We are unable to load the user's assembly into the main binding context because we are running from the NuGet location.

--- a/src/Sharpliner/build/Sharpliner.targets
+++ b/src/Sharpliner/build/Sharpliner.targets
@@ -1,11 +1,9 @@
 <Project>
-  <Target Name="PublishSharplinerDefinitions" AfterTargets="Build">
+  <Target Name="PublishSharplinerDefinitions" AfterTargets="Build" Condition="$(SkipSharpliner) != 'true'">
     <PropertyGroup>
       <_AssemblyToSearch>$(OutputPath)$(AssemblyName).dll</_AssemblyToSearch>
       <_FailIfChanged>false</_FailIfChanged>
       <_FailIfChanged Condition="$(FailIfChanged) == 'true'">true</_FailIfChanged>
-      <_Skip>false</_Skip>
-      <_Skip Condition="$(SkipSharpliner) == 'true'">true</_Skip>
     </PropertyGroup>
 
     <Message Importance="high" Text="Publishing all definitions inside $(_AssemblyToSearch)" />
@@ -19,6 +17,6 @@
     <Exec Command="dotnet build &quot;$(MSBuildProjectFullPath)&quot; /p:SharplinerVsBuild=true -c $(Configuration)"
           Condition=" '$(MSBuildRuntimeType)' != 'Core' and '$(SharplinerVsBuild)' != 'true' " />
 
-    <PublishDefinitions Assembly="$(_AssemblyToSearch)" FailIfChanged="$(_FailIfChanged)" Skip="$(_Skip)" Condition="'$(MSBuildRuntimeType)' == 'Core'" />
+    <PublishDefinitions Assembly="$(_AssemblyToSearch)" FailIfChanged="$(_FailIfChanged)" Condition="'$(MSBuildRuntimeType)' == 'Core'" />
   </Target>
 </Project>


### PR DESCRIPTION
running `dotnet build` when the sharpliner can take a while, no need to do this when we're skipping the publish definitions feature