### PR TITLE
chore: Add [ExcludeFromCodeCoverage] attribute to PublishDefinitions and SharplinerPublisher classes

### DIFF
--- a/src/Sharpliner/PublishDefinitions.cs
+++ b/src/Sharpliner/PublishDefinitions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
@@ -8,6 +9,7 @@ namespace Sharpliner;
 /// <summary>
 /// This is an MSBuild task that is run in user projects to publish YAMLs after build.
 /// </summary>
+[ExcludeFromCodeCoverage]
 public class PublishDefinitions : Microsoft.Build.Utilities.Task
 {
     /// <summary>

--- a/src/Sharpliner/SharplinerPublisher.cs
+++ b/src/Sharpliner/SharplinerPublisher.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -13,6 +14,7 @@ namespace Sharpliner;
 /// <summary>
 /// This is the main entrypoint that finds definitions via reflection and publishes YAMLs.
 /// </summary>
+[ExcludeFromCodeCoverage]
 public class SharplinerPublisher(TaskLoggingHelper logger)
 {
     /// <summary>

--- a/tests/Sharpliner.Tests/PublicApiExport.txt.verified.txt
+++ b/tests/Sharpliner.Tests/PublicApiExport.txt.verified.txt
@@ -2226,6 +2226,7 @@ namespace Sharpliner
     {
         System.Collections.Generic.IEnumerable<Sharpliner.ISharplinerDefinition> Definitions { get; }
     }
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class PublishDefinitions : Microsoft.Build.Utilities.Task
     {
         public PublishDefinitions() { }
@@ -2264,6 +2265,7 @@ namespace Sharpliner
             public Sharpliner.Common.ValidationSeverity RepositoryCheckouts { get; set; }
         }
     }
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class SharplinerPublisher
     {
         public SharplinerPublisher(Microsoft.Build.Utilities.TaskLoggingHelper logger) { }


### PR DESCRIPTION
these two files are covered by our integration tests and not the unit-tests, so no coverage collected for these

before:

| Module     | Line   | Branch | Method |
|-------------|-------|---------|----------|
| Sharpliner | 66.76% | 60.23% | 61.65% |

after:

| Module     | Line   | Branch | Method |
|-------------|-------|---------|----------|
| Sharpliner | 70.49% | 67.89% | 62.24%

next PR will remove the dead-code we have in `Condition.cs` (internal classes)