### PR TITLE
Fix: RelativeToGitRoot for git worktrees.

### DIFF
--- a/eng/DocsGenerator/Program.cs
+++ b/eng/DocsGenerator/Program.cs
@@ -158,7 +158,7 @@ public class Program
     private static string GetRelativeToGitRoot(string path)
     {
         var currentDir = new DirectoryInfo(Directory.GetCurrentDirectory());
-        while (!Directory.Exists(Path.Combine(currentDir.FullName, ".git")))
+        while (!Directory.Exists(Path.Combine(currentDir.FullName, ".git")) && !File.Exists(Path.Combine(currentDir.FullName, ".git")))
         {
             currentDir = currentDir.Parent;
 

--- a/eng/Sharpliner.CI/ProjectBuildSteps.cs
+++ b/eng/Sharpliner.CI/ProjectBuildSteps.cs
@@ -45,7 +45,7 @@ class ProjectBuildSteps(string project) : StepLibrary
     private static string GetGlobalJsonPath()
     {
         var currentDir = new DirectoryInfo(Directory.GetCurrentDirectory());
-        while (!Directory.Exists(Path.Combine(currentDir.FullName, ".git")))
+        while (!Directory.Exists(Path.Combine(currentDir.FullName, ".git")) && !File.Exists(Path.Combine(currentDir.FullName, ".git")))
         {
             currentDir = currentDir.Parent;
 

--- a/src/Sharpliner/SharplinerPublisher.cs
+++ b/src/Sharpliner/SharplinerPublisher.cs
@@ -188,7 +188,8 @@ public class SharplinerPublisher(TaskLoggingHelper logger)
         {
             case TargetPathType.RelativeToGitRoot:
                 var currentDir = new DirectoryInfo(Directory.GetCurrentDirectory());
-                while (!Directory.Exists(Path.Combine(currentDir.FullName, ".git")))
+
+                while (!Directory.Exists(Path.Combine(currentDir.FullName, ".git")) && !File.Exists(Path.Combine(currentDir.FullName, ".git")))
                 {
                     currentDir = currentDir.Parent;
 


### PR DESCRIPTION
This allows Sharpliner to use the RelativeToGitRoot Path Type [on a Git Worktree](https://git-scm.com/docs/git-worktree).  Git Worktrees do not contain a .git Directory, however, they contain a .git file, which is used as a sort of "pointer" file to the main checkout.  Looking for both this file as well as the directory covers both scenarios.