### PR TITLE
Fix: Environment tags in deploy jobs

### DIFF
--- a/src/Sharpliner/AzureDevOps/Model/Environment.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Environment.cs
@@ -35,7 +35,14 @@ public record Environment
     /// <summary>
     /// Tag names to filter the resources in the environment
     /// </summary>
+    [YamlIgnore]
     public List<string> Tags { get; init; } = [];
+
+    /// <summary>
+    /// Internal property to serialize the tags as a comma-separated string.
+    /// </summary>
+    [YamlMember(Alias = "tags")]
+    public string? _Tags => Tags.Count > 0 ? string.Join(",", Tags) : null;
 
     /// <summary>
     /// Instantiates a new <see cref="Environment"/> with the specified name and optional resource name.

--- a/tests/Sharpliner.Tests/AzureDevOps/TemplateTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/TemplateTests.cs
@@ -233,7 +233,10 @@ public class TemplateTests
 
         public DeploymentJob Deployment { get; init; } = new("deploy", "Deploy job")
         {
-            Environment = new("production"),
+            Environment = new("production")
+            {
+                Tags = ["group-a", "group-b"]
+            },
             Strategy = new RunOnceStrategy
             {
                 Deploy = new()

--- a/tests/Sharpliner.Tests/PublicApiExport.txt.verified.txt
+++ b/tests/Sharpliner.Tests/PublicApiExport.txt.verified.txt
@@ -405,7 +405,10 @@ namespace Sharpliner.AzureDevOps
         public int? ResourceId { get; init; }
         public string? ResourceName { get; init; }
         public Sharpliner.AzureDevOps.ResourceType? ResourceType { get; init; }
+        [YamlDotNet.Serialization.YamlIgnore]
         public System.Collections.Generic.List<string> Tags { get; init; }
+        [YamlDotNet.Serialization.YamlMember(Alias="tags")]
+        public string? _Tags { get; }
     }
     public sealed class EnvironmentVariableReference : Sharpliner.AzureDevOps.VariableReferenceBase
     {

--- a/tests/Sharpliner.Tests/Verified/AzureDevOps/TemplateTests.Job_Typed_Template_Definition_Serialization_Test.verified.txt
+++ b/tests/Sharpliner.Tests/Verified/AzureDevOps/TemplateTests.Job_Typed_Template_Definition_Serialization_Test.verified.txt
@@ -13,6 +13,7 @@
     displayName: Deploy job
     environment:
       name: production
+      tags: group-a,group-b
     strategy:
       runOnce:
         deploy:


### PR DESCRIPTION
Currently, when making a deploy job and setting the environment, if we set Tags, they are set like this:

```
environment:
  tags:
  - tag1
  - tag2
```

The issue is, Azure expects this to be a comma delimited string.  This fix makes it so we would instead get this:

```
environment:
  tags: tag1, tag2
```