### PR TITLE
Fixed: Git Relative Templates Not Referenced Correctly

### DIFF
--- a/src/Sharpliner/AzureDevOps/PublicDefinitions.cs
+++ b/src/Sharpliner/AzureDevOps/PublicDefinitions.cs
@@ -131,7 +131,14 @@ public abstract class ExtendsTemplateDefinition<TParameters> : ExtendsTemplateDe
     /// <param name="definition">The typed template definition</param>
     public static implicit operator Template<Extends>(ExtendsTemplateDefinition<TParameters> definition)
     {
-        return new Template<Extends>(definition.TargetFile, TypedTemplateUtils<TParameters>.ToTemplateParameters(definition._typedParameters));
+        string path = definition.TargetFile;
+
+        if (definition.TargetPathType == TargetPathType.RelativeToGitRoot)
+        {
+            path = "/" + path;
+        }
+
+        return new Template<Extends>(path, TypedTemplateUtils<TParameters>.ToTemplateParameters(definition._typedParameters));
     }
 }
 

--- a/src/Sharpliner/AzureDevOps/TemplateDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/TemplateDefinition.cs
@@ -195,7 +195,14 @@ public abstract class TemplateDefinition<T, TParameters> : TemplateDefinition<T>
     /// <param name="definition">The typed template definition</param>
     public static implicit operator Template<T>(TemplateDefinition<T, TParameters> definition)
     {
-        return new Template<T>(definition.TargetFile, TypedTemplateUtils<TParameters>.ToTemplateParameters(definition._typedParameters));
+        string path = definition.TargetFile;
+
+        if (definition.TargetPathType == TargetPathType.RelativeToGitRoot)
+        {
+            path = "/" + path;
+        }
+
+        return new Template<T>(path, TypedTemplateUtils<TParameters>.ToTemplateParameters(definition._typedParameters));
     }
 }
 

--- a/tests/Sharpliner.Tests/Verified/AzureDevOps/TemplateTests.Stage_Typed_Template_Definition_Relative_To_Git_Serialization_Test.verified.txt
+++ b/tests/Sharpliner.Tests/Verified/AzureDevOps/TemplateTests.Stage_Typed_Template_Definition_Relative_To_Git_Serialization_Test.verified.txt
@@ -1,0 +1,27 @@
+﻿parameters:
+- name: setupStages
+  type: stageList
+  default: []
+
+- name: mainStage
+  type: stage
+
+stages:
+- stage: initialize
+  displayName: Initialize stage
+
+- ${{ parameters.mainStage }}
+
+- stage: finalize
+  displayName: Finalize stage
+
+- stage: with-templates
+  jobs:
+  - template: /job-template.yml
+    parameters:
+      mainJob:
+        job: main
+        displayName: Main job
+        steps:
+        - bash: |-
+            echo 'Main job step'


### PR DESCRIPTION
Currently, in Azure DevOps when we are referencing TemplateDefinitions, we are not taking into account if the file path of the template definition is meant to be relative to the git root.  This means when we reference a template that is being saved in `template/run-git.yaml`, and we attempt to reference it later in a pipeline that exists at `yaml/main-pipeline.yaml`, we create this output in `main-pipeline.yaml`:
```
    - template: template/run-git.yaml
```

The reason this is an issue is because when we run `yaml/main-pipeline.yaml`, it will attempt to call that template relative to itself, starting at `yaml`, leading to the wrong area.  To fix this, when a template is relative to the git root, Azure DevOps expects it to begin with `/`, looking like this:

```
    - template: /template/run-git.yaml
```

This fix makes it so, if a TemplateDefinition is set to be Relative to the Git Root, it will add a '/' to its filename when serialized.