### PR TITLE
Elseif condition

### DIFF
--- a/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
@@ -537,7 +537,7 @@ public abstract class AzureDevOpsDefinition
     ///   - group: prod
     /// </code>
     /// </summary>
-    protected static IfConditionBuilder If => new();
+    protected static IfConditionBuilder If => new(null, false);
 
     /// <summary>
     /// Start an <c>${{ else () }}</c> section.

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/Condition.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/Condition.cs
@@ -25,6 +25,7 @@ public abstract class Condition : IYamlConvertible
     internal const string ExpressionEnd = " }}";
 
     internal const string IfTagStart = $"{ExpressionStart}if ";
+    internal const string ElseIfTagStart = $"{ExpressionStart}elseif ";
     internal const string ElseTagStart = $"{ExpressionStart}else";
 
     private const string VariableIndexAccessStart = "variables[";

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/Conditioned.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/Conditioned.cs
@@ -251,6 +251,43 @@ public record Conditioned<T> : Conditioned
     public IfConditionBuilder<T> If => new(this);
 
     /// <summary>
+    /// Starts a new <c>${{ elseif (...) }}</c> section.
+    /// For example:
+    /// <code lang="csharp">
+    /// If.IsBranch("dev")
+    ///     .Group("Development")
+    /// ElseIf.IsBranch("prod")
+    ///     .Group("Production")
+    /// </code>
+    /// will generate:
+    /// <code lang="yaml">
+    /// - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/dev') }}:
+    ///   - group: Development
+    /// - ${{ elseif eq(variables['Build.SourceBranch'], 'refs/heads/prod') }}:
+    ///   - group: Production
+    /// </code>
+    /// </summary>
+    public IfConditionBuilder ElseIf
+    {
+        get
+        {
+            // If we're top-level, we create a fake new top with empty definition to collect all the definitions
+            if (Parent == null)
+            {
+                Parent = new Conditioned<T>();
+                Parent.Definitions.Add(this);
+            }
+
+            if (Condition == null)
+            {
+                throw new InvalidOperationException("No condition to match ElseIf against");
+            }
+
+            return new IfConditionBuilder(Parent, true);
+        }
+    }
+
+    /// <summary>
     /// Ends a <c>${{ if (...) }}</c> section.
     /// For example:
     /// <code lang="csharp">

--- a/src/Sharpliner/AzureDevOps/ConditionedExpressions/IfConditionBuilder.cs
+++ b/src/Sharpliner/AzureDevOps/ConditionedExpressions/IfConditionBuilder.cs
@@ -9,11 +9,15 @@ namespace Sharpliner.AzureDevOps.ConditionedExpressions;
 /// </summary>
 public class IfConditionBuilder
 {
+    internal bool IsElseIf { get; } = false;
     internal Conditioned? Parent { get; }
 
-    internal IfConditionBuilder(Conditioned? parent = null)
+    internal IfConditionBuilder(Conditioned? parent = null) : this(parent, false) { }
+
+    internal IfConditionBuilder(Conditioned? parent = null, bool isElseIf = false)
     {
         Parent = parent;
+        IsElseIf = isElseIf;
     }
 
     /// <summary>
@@ -423,6 +427,7 @@ public class IfConditionBuilder
     private IfCondition Link(IfCondition condition)
     {
         condition.Parent = Parent;
+        condition.IsElseIf = IsElseIf;
         return condition;
     }
 }
@@ -433,11 +438,15 @@ public class IfConditionBuilder
 /// </summary>
 public class IfConditionBuilder<T>
 {
+    internal bool IsElseIf { get; } = false;
     internal Conditioned<T>? Parent { get; }
 
-    internal IfConditionBuilder(Conditioned<T>? parent = null)
+    internal IfConditionBuilder(Conditioned<T>? parent = null) : this(parent, false) { }
+
+    internal IfConditionBuilder(Conditioned<T>? parent = null, bool isElseIf = false)
     {
         Parent = parent;
+        IsElseIf = isElseIf;
     }
 
     /// <summary>
@@ -961,6 +970,7 @@ public class IfConditionBuilder<T>
     private IfCondition<T> Link(IfCondition<T> condition)
     {
         condition.Parent = Parent;
+        condition.IsElseIf = IsElseIf;
         return condition;
     }
 }

--- a/src/Sharpliner/AzureDevOps/IfCondition.cs
+++ b/src/Sharpliner/AzureDevOps/IfCondition.cs
@@ -7,11 +7,17 @@ namespace Sharpliner.AzureDevOps;
 /// </summary>
 public abstract class IfCondition : Condition
 {
+    internal bool IsElseIf = false;
+
+    internal override string TagStart => IsElseIf ? ElseIfTagStart : IfTagStart;
+
     private static readonly (string Start, string End)[] s_tagsToRemove =
     [
         (IfTagStart, ExpressionEnd),
+        (ElseIfTagStart, ExpressionEnd),
         (ElseTagStart, ExpressionEnd),
         ('\'' + IfTagStart, ExpressionEnd + '\''),
+        ('\'' + ElseIfTagStart, ExpressionEnd + '\''),
         ('\'' + ElseTagStart, ExpressionEnd + '\''),
         (ExpressionStart, ExpressionEnd),
         ('\'' + ExpressionStart, ExpressionEnd + '\''),
@@ -41,8 +47,8 @@ public abstract class IfCondition : Condition
         return condition;
     }
 
-    internal static string WrapTag(string condition) =>
-        IfTagStart + condition + ExpressionEnd;
+    internal string WrapTag(string condition) =>
+        TagStart + condition + ExpressionEnd;
 }
 
 /// <summary>

--- a/tests/Sharpliner.Tests/AzureDevOps/ConditionedExpressions/ConditionalsTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/ConditionedExpressions/ConditionalsTests.cs
@@ -164,8 +164,7 @@ public class ConditionalsTests
                                 {
                                     Demands = { "SomeProperty -equals SomeValue" }
                                 })
-                            .EndIf
-                            .If.Equal("C", "D")
+                            .ElseIf.Equal("C", "D")
                                 .Pool(new HostedPool("pool-B")),
                 }
             }

--- a/tests/Sharpliner.Tests/PublicApiExport.txt.verified.txt
+++ b/tests/Sharpliner.Tests/PublicApiExport.txt.verified.txt
@@ -1309,6 +1309,7 @@ namespace Sharpliner.AzureDevOps.ConditionedExpressions
         protected Conditioned(Sharpliner.AzureDevOps.IfCondition? condition) { }
         public Conditioned(T definition) { }
         public Sharpliner.AzureDevOps.IfCondition<T> Else { get; }
+        public Sharpliner.AzureDevOps.ConditionedExpressions.IfConditionBuilder ElseIf { get; }
         public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<T> EndEach { get; }
         public Sharpliner.AzureDevOps.ConditionedExpressions.Conditioned<T> EndIf { get; }
         public Sharpliner.AzureDevOps.ConditionedExpressions.IfConditionBuilder<T> If { get; }

--- a/tests/Sharpliner.Tests/Verified/AzureDevOps.ConditionedExpressions/ConditionalsTests.ConditionedValueWithElseIf_Test.verified.txt
+++ b/tests/Sharpliner.Tests/Verified/AzureDevOps.ConditionedExpressions/ConditionalsTests.ConditionedValueWithElseIf_Test.verified.txt
@@ -5,5 +5,5 @@
       name: pool-A
       demands:
       - SomeProperty -equals SomeValue
-    ${{ if eq('C', 'D') }}:
+    ${{ elseif eq('C', 'D') }}:
       name: pool-B


### PR DESCRIPTION
While working with Sharpliner I noticed there was no way to invoke an ${{ elseif }} call.  This update adds .ElseIf as a Conditioned object, which will allow for elseifs like so:

```
If.Equal("A", "B")
  .Pool(new HostedPool("pool-A")
  {
      Demands = { "SomeProperty -equals SomeValue" }
  })
  .ElseIf.Equal("C", "D")
  .Pool(new HostedPool("pool-B"))
```

outputs:
```
${{ if eq('A', 'B') }}:
  name: pool-A
  demands:
  - SomeProperty -equals SomeValue
${{ elseif eq('C', 'D') }}:
  name: pool-B
```

I've updated a test that was meant to do ElseIf statements to utilize this.