### PR TITLE
Update dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,9 +6,9 @@
   <ItemGroup>
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="FluentAssertions" Version="7.1.0" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="17.12.6" />
-    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.12.6" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="17.14.28" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.14.28" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -16,12 +16,11 @@
     <PackageVersion Include="OneOf.SourceGenerator" Version="3.0.271" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="PublicApiGenerator" Version="11.4.1" />
-    <PackageVersion Include="Verify.Xunit" Version="28.9.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
+    <PackageVersion Include="Verify.Xunit" Version="31.1.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
-
   <!-- Test libraries (we test referencing the Sharpliner library) -->
   <ItemGroup>
     <PackageVersion Include="Sharpliner" Version="43.43.43" />


### PR DESCRIPTION
- Updated Microsoft.Build packages from 17.12.x to 17.14.28
- Updated Microsoft.NET.Test.Sdk from 17.12.0 to 18.0.0
- Updated Verify.Xunit from 28.9.0 to 31.1.0
- Updated xunit.runner.visualstudio from 3.0.1 to 3.1.5