### PR TITLE
Fix PipelineTrigger.Stages and Tags to use flat list instead of InclusionRule

### DIFF
--- a/src/Sharpliner/AzureDevOps/Model/PipelineTrigger.cs
+++ b/src/Sharpliner/AzureDevOps/Model/PipelineTrigger.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Sharpliner.AzureDevOps.Expressions;
 
@@ -22,18 +23,20 @@ public record PipelineTrigger
     public InclusionRule? Branches { get; init; }
 
     /// <summary>
-    /// List of tags to evaluate for trigger event
+    /// List of tags to evaluate for trigger event.
+    /// See <see href="https://learn.microsoft.com/en-us/azure/devops/pipelines/process/pipeline-triggers?view=azure-devops#tag-filters">tag filters</see>.
     /// Optional, 2020.1 and greater
     /// </summary>
     [DisallowNull]
-    public InclusionRule? Tags { get; init; }
+    public List<string>? Tags { get; init; }
 
     /// <summary>
-    /// List of stages to evaluate for trigger event
+    /// List of stages to evaluate for trigger event.
+    /// See <see href="https://learn.microsoft.com/en-us/azure/devops/pipelines/process/pipeline-triggers?view=azure-devops#stage-filters">stage filters</see>.
     /// Optional, 2020.1 and greater
     /// </summary>
     [DisallowNull]
-    public InclusionRule? Stages { get; init; }
+    public List<string>? Stages { get; init; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PipelineTrigger"/> class.

--- a/tests/Sharpliner.Tests/AzureDevOps/Model/PipelineResourceSerializationTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/Model/PipelineResourceSerializationTests.cs
@@ -138,4 +138,36 @@ public class PipelineResourceSerializationTests
 
         return Verify(pipeline.Serialize());
     }
+
+    private class ResourcePipelineWithStagesAndTags : SingleStagePipelineDefinition
+    {
+        public override string TargetFile => "foo.yaml";
+
+        public override SingleStagePipeline Pipeline => new()
+        {
+            Resources = new Resources()
+            {
+                Pipelines =
+                {
+                    new PipelineResource("source-pipeline")
+                    {
+                        Source = "TriggeringPipeline",
+                        Trigger = new PipelineTrigger(["main"])
+                        {
+                            Stages = ["PreProduction", "Production"],
+                            Tags = ["production", "signed"],
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    [Fact]
+    public Task ResourcePipeline_StagesAndTags_Serialization_Test()
+    {
+        var pipeline = new ResourcePipelineWithStagesAndTags();
+
+        return Verify(pipeline.Serialize());
+    }
 }

--- a/tests/Sharpliner.Tests/PublicApiExport.txt.verified.txt
+++ b/tests/Sharpliner.Tests/PublicApiExport.txt.verified.txt
@@ -802,8 +802,8 @@ namespace Sharpliner.AzureDevOps
         public PipelineTrigger(params string[] branches) { }
         public Sharpliner.AzureDevOps.Expressions.AdoExpression<bool>? Batch { get; init; }
         public Sharpliner.AzureDevOps.InclusionRule? Branches { get; init; }
-        public Sharpliner.AzureDevOps.InclusionRule? Stages { get; init; }
-        public Sharpliner.AzureDevOps.InclusionRule? Tags { get; init; }
+        public System.Collections.Generic.List<string>? Stages { get; init; }
+        public System.Collections.Generic.List<string>? Tags { get; init; }
     }
     public sealed class PipelineVariableReference : Sharpliner.AzureDevOps.VariableReferenceBase
     {

--- a/tests/Sharpliner.Tests/Verified/AzureDevOps/PipelineResourceSerializationTests.ResourcePipeline_StagesAndTags_Serialization_Test.verified.txt
+++ b/tests/Sharpliner.Tests/Verified/AzureDevOps/PipelineResourceSerializationTests.ResourcePipeline_StagesAndTags_Serialization_Test.verified.txt
@@ -1,0 +1,14 @@
+﻿resources:
+  pipelines:
+  - pipeline: source-pipeline
+    source: TriggeringPipeline
+    trigger:
+      branches:
+        include:
+        - main
+      tags:
+      - production
+      - signed
+      stages:
+      - PreProduction
+      - Production


### PR DESCRIPTION
## Problem

`PipelineTrigger.Stages` and `PipelineTrigger.Tags` are typed as `InclusionRule?`, which serializes with include:/exclude: nesting. However, the Azure DevOps YAML schema only supports flat lists for both 
stages and tags in pipeline resource triggers — unlike branches which does support include/exclude.

### Generated (incorrect):

```yaml
 trigger:
   stages:
     include:
     - build
 ```

### Expected (per ADO schema):

```yaml
 trigger:
   stages:
   - build
  ```

## Fix

Changed Stages and Tags from `InclusionRule?` to `List<string>?` on `PipelineTrigger`.

References

 - Stage filters docs (https://learn.microsoft.com/en-us/azure/devops/pipelines/process/pipeline-triggers?view=azure-devops#stage-filters)
 - Tag filters docs (https://learn.microsoft.com/en-us/azure/devops/pipelines/process/pipeline-triggers?view=azure-devops#tag-filters)
 - YAML schema: resources.pipelines.pipeline (https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/resources-pipelines-pipeline?view=azure-pipelines) — shows stages: [ string ] and tags:
 [ string ]