### PR TITLE
Fix #534: preserve conditional expressions on scalar AdoExpression properties

### DIFF
--- a/src/Sharpliner/AzureDevOps/Expressions/AdoExpression.cs
+++ b/src/Sharpliner/AzureDevOps/Expressions/AdoExpression.cs
@@ -101,6 +101,14 @@ public abstract record AdoExpression : IYamlConvertible
 
     internal abstract void WriteInternal(IEmitter emitter, ObjectSerializer nestedObjectSerializer);
 
+    /// <summary>
+    /// Returns the boxed value of <see cref="AdoExpression{T}.Definition"/> for this node, or
+    /// <see langword="null"/> if this node has no direct value (e.g. it is a parent that holds
+    /// child <see cref="Definitions"/> only). Used by serialization helpers that need to inspect
+    /// the value without knowing the generic parameter.
+    /// </summary>
+    internal virtual object? GetDefinitionValue() => null;
+
     internal virtual void SetIsList(bool isList)
     {
         IsList = isList;
@@ -327,6 +335,8 @@ public record AdoExpression<T> : AdoExpression
     /// </summary>
     internal T? Definition { get; }
 
+    internal override object? GetDefinitionValue() => Definition;
+
     internal AdoExpression(T definition, IfCondition condition) : base(condition)
     {
         Definition = definition;
@@ -355,6 +365,12 @@ public record AdoExpression<T> : AdoExpression
     protected AdoExpression() : base((IfCondition?)null)
     {
     }
+
+    /// <summary>
+    /// Internal factory for creating an empty <see cref="AdoExpression{T}"/> to act as a
+    /// synthetic root for an If/ElseIf/Else chain.
+    /// </summary>
+    internal static AdoExpression<T> CreateEmpty() => new();
 
     /// <summary>
     /// Starts a new <c>${{ if (...) }}</c> section.

--- a/src/Sharpliner/AzureDevOps/Expressions/AdoExpressionConversion.cs
+++ b/src/Sharpliner/AzureDevOps/Expressions/AdoExpressionConversion.cs
@@ -1,0 +1,75 @@
+﻿using System;
+
+namespace Sharpliner.AzureDevOps.Expressions;
+
+/// <summary>
+/// Helpers for converting a scalar <see cref="AdoExpression{TSrc}"/> tree (including
+/// If/ElseIf/Else branches) into a mirror <see cref="AdoExpression{TDst}"/> tree by
+/// applying a converter function to each leaf value.
+///
+/// <para>
+/// This is used by computed properties such as <c>JobBase.TimeoutInMinutes</c> that
+/// need to expose a converted view (TimeSpan → int minutes) while preserving any
+/// conditional <c>${{ if ... }}</c> branches authored on the source property.
+/// </para>
+/// </summary>
+internal static class AdoExpressionConversion
+{
+    /// <summary>
+    /// Mirrors the conditional structure of <paramref name="source"/> as a new
+    /// <see cref="AdoExpression{TDst}"/> tree, applying <paramref name="convert"/>
+    /// to each leaf value. Returns the leaf node equivalent to <paramref name="source"/>.
+    /// </summary>
+    public static AdoExpression<TDst>? ConvertScalar<TSrc, TDst>(
+        AdoExpression<TSrc>? source,
+        Func<TSrc, TDst> convert)
+    {
+        if (source is null)
+        {
+            return null;
+        }
+
+        // Walk to the topmost expression.
+        AdoExpression sourceRoot = source;
+        while (sourceRoot.Parent is not null)
+        {
+            sourceRoot = sourceRoot.Parent;
+        }
+
+        // No If/Else chain — single leaf.
+        if (sourceRoot.Condition is not null || sourceRoot.Definitions.Count == 0)
+        {
+            var value = source.Definition;
+            if (value is null)
+            {
+                return source.Condition is null
+                    ? null
+                    : new AdoExpression<TDst>(default!, source.Condition);
+            }
+            return source.Condition is null
+                ? new AdoExpression<TDst>(convert(value))
+                : new AdoExpression<TDst>(convert(value), source.Condition);
+        }
+
+        // Synthetic root (If/ElseIf/Else chain) — mirror all branches.
+        var dstRoot = AdoExpression<TDst>.CreateEmpty();
+        AdoExpression<TDst>? leaf = null;
+        foreach (var srcBranch in sourceRoot.Definitions)
+        {
+            if (srcBranch is not AdoExpression<TSrc> typed || typed.Condition is null)
+            {
+                continue;
+            }
+
+            TDst dstValue = typed.Definition is null ? default! : convert(typed.Definition);
+            var dstBranch = new AdoExpression<TDst>(dstValue, typed.Condition)
+            {
+                Parent = dstRoot
+            };
+            dstRoot.Definitions.Add(dstBranch);
+            leaf = dstBranch;
+        }
+
+        return leaf;
+    }
+}

--- a/src/Sharpliner/AzureDevOps/Model/JobBase.cs
+++ b/src/Sharpliner/AzureDevOps/Model/JobBase.cs
@@ -67,7 +67,8 @@ public abstract record JobBase : IDependsOn
     /// Time to wait for this job to complete before the server kills it.
     /// </summary>
     [YamlMember(Order = 800)]
-    public AdoExpression<int>? TimeoutInMinutes => Timeout?.Definition != null ? (int)Timeout.Definition.TotalMinutes : null;
+    public AdoExpression<int>? TimeoutInMinutes
+        => AdoExpressionConversion.ConvertScalar(Timeout, ts => (int)ts.TotalMinutes);
 
     /// <summary>
     /// How much time to give 'run always even if cancelled tasks' before killing them
@@ -80,7 +81,8 @@ public abstract record JobBase : IDependsOn
     /// Time to wait for the job to cancel before forcibly terminating it.
     /// </summary>
     [YamlMember(Order = 900)]
-    public AdoExpression<int>? CancelTimeoutInMinutes => CancelTimeout?.Definition != null ? (int)CancelTimeout.Definition.TotalMinutes : null;
+    public AdoExpression<int>? CancelTimeoutInMinutes
+        => AdoExpressionConversion.ConvertScalar(CancelTimeout, ts => (int)ts.TotalMinutes);
 
     /// <summary>
     /// What to clean up before the job runs

--- a/src/Sharpliner/AzureDevOps/Model/Step.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Step.cs
@@ -58,14 +58,7 @@ public abstract record Step
         init
         {
             field = value;
-            if (value?.Definition is not null)
-            {
-                TimeoutInMinutes = (int)value.Definition.TotalMinutes;
-            }
-            else if (value?.Condition is not null)
-            {
-                TimeoutInMinutes = new AdoExpression<int>(default, value.Condition);
-            }
+            TimeoutInMinutes = AdoExpressionConversion.ConvertScalar(value, ts => (int)ts.TotalMinutes);
         }
     }
 

--- a/src/Sharpliner/AzureDevOps/Serialization/ConditionalScalarTypeInspector.cs
+++ b/src/Sharpliner/AzureDevOps/Serialization/ConditionalScalarTypeInspector.cs
@@ -1,0 +1,251 @@
+﻿using System;
+using System.Collections.Generic;
+using Sharpliner.AzureDevOps.Expressions;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.TypeInspectors;
+
+namespace Sharpliner.AzureDevOps.Serialization;
+
+/// <summary>
+/// A YamlDotNet <see cref="ITypeInspector"/> decorator that handles conditional
+/// <see cref="AdoExpression{T}"/> properties where <c>T</c> is a scalar (primitive,
+/// enum, string, <see cref="TimeSpan"/>, or <see cref="decimal"/>).
+///
+/// <para>
+/// YamlDotNet emits the property key before invoking the value's serializer, and the
+/// value-position serializer cannot inject sibling keys into the parent mapping. For
+/// mapping-typed properties (e.g. <c>Pool</c>) this is fine because the value can be
+/// replaced by a <c>${{ if ... }}: { ... }</c> mapping. For scalar properties this is
+/// impossible — emitting <c>timeoutInMinutes:\n  ${{ if ... }}: 60</c> is invalid
+/// Azure Pipelines syntax. So we must lift the conditional up to the parent mapping
+/// as a sibling key: <c>${{ if ... }}: { timeoutInMinutes: 60 }</c>.
+/// </para>
+/// </summary>
+internal sealed class ConditionalScalarTypeInspector : TypeInspectorSkeleton
+{
+    private readonly ITypeInspector _inner;
+
+    public ConditionalScalarTypeInspector(ITypeInspector inner)
+    {
+        _inner = inner;
+    }
+
+    public override string GetEnumName(Type enumType, string name) => _inner.GetEnumName(enumType, name);
+
+    public override string GetEnumValue(object enumValue) => _inner.GetEnumValue(enumValue);
+
+    public override IEnumerable<IPropertyDescriptor> GetProperties(Type type, object? container)
+    {
+        var properties = _inner.GetProperties(type, container);
+
+        if (container is null)
+        {
+            return properties;
+        }
+
+        List<IPropertyDescriptor>? rewritten = null;
+        var originals = new List<IPropertyDescriptor>();
+
+        foreach (var prop in properties)
+        {
+            originals.Add(prop);
+            if (TryExpandConditional(prop, container, out var expanded))
+            {
+                if (rewritten is null)
+                {
+                    // Copy any properties we've already seen
+                    rewritten = new List<IPropertyDescriptor>(originals.Count - 1);
+                    for (int i = 0; i < originals.Count - 1; i++)
+                    {
+                        rewritten.Add(originals[i]);
+                    }
+                }
+
+                foreach (var d in expanded!)
+                {
+                    rewritten.Add(d);
+                }
+            }
+            else
+            {
+                rewritten?.Add(prop);
+            }
+        }
+
+        return rewritten ?? (IEnumerable<IPropertyDescriptor>)originals;
+    }
+
+    private static bool TryExpandConditional(
+        IPropertyDescriptor prop,
+        object container,
+        out List<IPropertyDescriptor>? expanded)
+    {
+        expanded = null;
+
+        if (!IsScalarAdoExpression(prop.Type))
+        {
+            return false;
+        }
+
+        IObjectDescriptor descriptor;
+        try
+        {
+            descriptor = prop.Read(container);
+        }
+        catch
+        {
+            return false;
+        }
+
+        if (descriptor.Value is not AdoExpression expression)
+        {
+            return false;
+        }
+
+        if (expression.Condition is null && expression.Parent is null)
+        {
+            // Plain value with no condition — let YamlDotNet handle it normally.
+            return false;
+        }
+
+        var innerType = prop.Type.GetGenericArguments()[0];
+
+        // Walk up to the root. For If/ElseIf/Else chains, the root is a synthetic
+        // AdoExpression created by `Else` / `ElseIf` getters: it has a null Condition
+        // and holds each branch in `Definitions`. For a simple `If.X.Value(...)`,
+        // there is no parent and the expression itself is the only branch.
+        var root = expression;
+        while (root.Parent is not null)
+        {
+            root = root.Parent;
+        }
+
+        var branches = new List<AdoExpression>();
+        if (root.Condition is null)
+        {
+            // Synthetic root — collect each conditional branch from Definitions.
+            foreach (var def in root.Definitions)
+            {
+                if (def is AdoExpression branch && branch.Condition is not null)
+                {
+                    branches.Add(branch);
+                }
+            }
+        }
+        else
+        {
+            branches.Add(root);
+        }
+
+        if (branches.Count == 0)
+        {
+            return false;
+        }
+
+        expanded = new List<IPropertyDescriptor>(branches.Count);
+        foreach (var branch in branches)
+        {
+            expanded.Add(new ConditionalKeyPropertyDescriptor(
+                key: branch.Condition!.ToString()!,
+                order: prop.Order,
+                innerName: prop.Name,
+                innerType: innerType,
+                innerValue: branch.GetDefinitionValue()));
+        }
+
+        return true;
+    }
+
+    private static bool IsScalarAdoExpression(Type type)
+    {
+        if (!type.IsGenericType || type.GetGenericTypeDefinition() != typeof(AdoExpression<>))
+        {
+            return false;
+        }
+
+        var inner = type.GetGenericArguments()[0];
+        var nonNullable = Nullable.GetUnderlyingType(inner) ?? inner;
+        return nonNullable.IsPrimitive
+            || nonNullable.IsEnum
+            || nonNullable == typeof(string)
+            || nonNullable == typeof(TimeSpan)
+            || nonNullable == typeof(decimal);
+    }
+
+    /// <summary>
+    /// A virtual <see cref="IPropertyDescriptor"/> whose name is a
+    /// <c>${{ if ... }}</c> expression and whose value is a single-entry mapping
+    /// containing the original property name and value.
+    /// </summary>
+    private sealed class ConditionalKeyPropertyDescriptor : IPropertyDescriptor
+    {
+        private readonly string _innerName;
+        private readonly Type _innerType;
+        private readonly object? _innerValue;
+
+        public ConditionalKeyPropertyDescriptor(
+            string key,
+            int order,
+            string innerName,
+            Type innerType,
+            object? innerValue)
+        {
+            Name = key;
+            Order = order;
+            _innerName = innerName;
+            _innerType = innerType;
+            _innerValue = innerValue;
+        }
+
+        public string Name { get; }
+        public int Order { get; set; }
+        public Type Type => typeof(InnerMappingValue);
+        public Type? TypeOverride { get; set; }
+        public Type? ConverterType => null;
+        public ScalarStyle ScalarStyle { get; set; } = ScalarStyle.Plain;
+        public bool CanWrite => false;
+        public bool AllowNulls => true;
+        public bool Required => false;
+
+        public T? GetCustomAttribute<T>() where T : System.Attribute => null;
+
+        public IObjectDescriptor Read(object target)
+            => new ObjectDescriptor(
+                new InnerMappingValue(_innerName, _innerType, _innerValue),
+                typeof(InnerMappingValue),
+                typeof(InnerMappingValue));
+
+        public void Write(object target, object? value)
+            => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// Emits a block-style mapping with a single entry: <c>innerName: innerValue</c>.
+    /// </summary>
+    private sealed class InnerMappingValue : IYamlConvertible
+    {
+        private readonly string _innerName;
+        private readonly Type _innerType;
+        private readonly object? _innerValue;
+
+        public InnerMappingValue(string innerName, Type innerType, object? innerValue)
+        {
+            _innerName = innerName;
+            _innerType = innerType;
+            _innerValue = innerValue;
+        }
+
+        public void Read(IParser parser, Type expectedType, ObjectDeserializer nestedObjectDeserializer)
+            => throw new NotSupportedException();
+
+        public void Write(IEmitter emitter, ObjectSerializer nestedObjectSerializer)
+        {
+            emitter.Emit(new MappingStart(AnchorName.Empty, TagName.Empty, isImplicit: true, MappingStyle.Block));
+            emitter.Emit(new Scalar(_innerName));
+            nestedObjectSerializer(_innerValue, _innerType);
+            emitter.Emit(new MappingEnd());
+        }
+    }
+}

--- a/src/Sharpliner/SharplinerSerializer.cs
+++ b/src/Sharpliner/SharplinerSerializer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text.RegularExpressions;
+using Sharpliner.AzureDevOps.Serialization;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -30,6 +31,7 @@ public static class SharplinerSerializer
         var serializerBuilder = new SerializerBuilder()
             .WithNamingConvention(CamelCaseNamingConvention.Instance)
             .WithTypeConverter(new YamlStringEnumConverter())
+            .WithTypeInspector(inner => new ConditionalScalarTypeInspector(inner))
             .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitDefaults | DefaultValuesHandling.OmitEmptyCollections)
             .WithEventEmitter(nextEmitter => new MultilineStringEmitter(nextEmitter))
             .DisableAliases();

--- a/tests/Sharpliner.Tests/AzureDevOps/Model/ConditionalScalarPropertyTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/Model/ConditionalScalarPropertyTests.cs
@@ -1,0 +1,240 @@
+using System;
+using Sharpliner.AzureDevOps;
+using Sharpliner.AzureDevOps.Expressions;
+using Sharpliner.AzureDevOps.Tasks;
+
+namespace Sharpliner.Tests.AzureDevOps;
+
+public class ConditionalScalarPropertyTests
+{
+    private class ConditionalTimeoutPipeline : SimpleTestPipeline
+    {
+        public override SingleStagePipeline Pipeline => new()
+        {
+            Jobs =
+            {
+                new Job("Deployment", "Deployment")
+                {
+                    Timeout = If.In("parameters.rolloutInfra", "'Test'", "'PPE'")
+                        .Value(TimeSpan.FromMinutes(60)),
+                    CancelTimeout = If.Equal("parameters.rolloutInfra", "'Prod'")
+                        .Value(TimeSpan.FromMinutes(5)),
+                }
+            }
+        };
+    }
+
+    [Fact]
+    public Task ConditionalTimeout_Preserves_Condition_Test()
+    {
+        ConditionalTimeoutPipeline pipeline = new();
+
+        return Verify(pipeline.Serialize());
+    }
+
+    private class UnconditionalTimeoutPipeline : SimpleTestPipeline
+    {
+        public override SingleStagePipeline Pipeline => new()
+        {
+            Jobs =
+            {
+                new Job("Deployment", "Deployment")
+                {
+                    Timeout = TimeSpan.FromMinutes(60),
+                    CancelTimeout = TimeSpan.FromMinutes(5),
+                }
+            }
+        };
+    }
+
+    [Fact]
+    public Task UnconditionalTimeout_Test()
+    {
+        UnconditionalTimeoutPipeline pipeline = new();
+
+        return Verify(pipeline.Serialize());
+    }
+
+    private class ConditionalStepTimeoutPipeline : SimpleStepTestPipeline
+    {
+        protected override AdoExpressionList<Step> Steps =>
+        [
+            new InlineBashTask("echo hi")
+            {
+                Timeout = If.In("parameters.rolloutInfra", "'Test'", "'PPE'")
+                    .Value(TimeSpan.FromMinutes(60)),
+            }
+        ];
+    }
+
+    [Fact]
+    public Task ConditionalStepTimeout_Preserves_Condition_Test()
+    {
+        ConditionalStepTimeoutPipeline pipeline = new();
+
+        return Verify(pipeline.Serialize());
+    }
+
+    private class ConditionalStepTimeout_IfElsePipeline : SimpleStepTestPipeline
+    {
+        protected override AdoExpressionList<Step> Steps =>
+        [
+            new InlineBashTask("echo hi")
+            {
+                Timeout = If.In("parameters.rolloutInfra", "'Test'", "'PPE'")
+                    .Value(TimeSpan.FromMinutes(60))
+                    .Else
+                    .Value(TimeSpan.FromMinutes(120)),
+            }
+        ];
+    }
+
+    [Fact]
+    public Task ConditionalStepTimeout_IfElse_Test()
+    {
+        ConditionalStepTimeout_IfElsePipeline pipeline = new();
+
+        return Verify(pipeline.Serialize());
+    }
+
+    private class ConditionalStepTimeout_IfElseIfElsePipeline : SimpleStepTestPipeline
+    {
+        protected override AdoExpressionList<Step> Steps =>
+        [
+            new InlineBashTask("echo hi")
+            {
+                Timeout = If.Equal("parameters.rolloutInfra", "'Test'")
+                    .Value(TimeSpan.FromMinutes(30))
+                    .ElseIf.Equal("parameters.rolloutInfra", "'PPE'")
+                    .Value(TimeSpan.FromMinutes(60))
+                    .Else
+                    .Value(TimeSpan.FromMinutes(120)),
+            }
+        ];
+    }
+
+    [Fact]
+    public Task ConditionalStepTimeout_IfElseIfElse_Test()
+    {
+        ConditionalStepTimeout_IfElseIfElsePipeline pipeline = new();
+
+        return Verify(pipeline.Serialize());
+    }
+
+    private class ConditionalContinueOnErrorPipeline : SimpleStepTestPipeline
+    {
+        protected override AdoExpressionList<Step> Steps =>
+        [
+            new InlineBashTask("echo hi")
+            {
+                ContinueOnError = If.Equal("variables['Build.Reason']", "'PullRequest'").Value(true),
+            }
+        ];
+    }
+
+    [Fact]
+    public Task ConditionalContinueOnError_Preserves_Condition_Test()
+    {
+        ConditionalContinueOnErrorPipeline pipeline = new();
+
+        return Verify(pipeline.Serialize());
+    }
+
+    private class ConditionalContinueOnError_IfElsePipeline : SimpleStepTestPipeline
+    {
+        protected override AdoExpressionList<Step> Steps =>
+        [
+            new InlineBashTask("echo hi")
+            {
+                ContinueOnError = If.Equal("variables['Build.Reason']", "'PullRequest'")
+                    .Value(true)
+                    .Else
+                    .Value(false),
+            }
+        ];
+    }
+
+    [Fact]
+    public Task ConditionalContinueOnError_IfElse_Test()
+    {
+        ConditionalContinueOnError_IfElsePipeline pipeline = new();
+
+        return Verify(pipeline.Serialize());
+    }
+
+    private class ConditionalContinueOnError_IfElseIfElsePipeline : SimpleStepTestPipeline
+    {
+        protected override AdoExpressionList<Step> Steps =>
+        [
+            new InlineBashTask("echo hi")
+            {
+                ContinueOnError = If.Equal("variables['Build.Reason']", "'PullRequest'")
+                    .Value(true)
+                    .ElseIf.Equal("variables['Build.Reason']", "'Manual'")
+                    .Value(false)
+                    .Else
+                    .Value(true),
+            }
+        ];
+    }
+
+    [Fact]
+    public Task ConditionalContinueOnError_IfElseIfElse_Test()
+    {
+        ConditionalContinueOnError_IfElseIfElsePipeline pipeline = new();
+
+        return Verify(pipeline.Serialize());
+    }
+
+    private class ConditionalTimeout_IfElsePipeline : SimpleTestPipeline
+    {
+        public override SingleStagePipeline Pipeline => new()
+        {
+            Jobs =
+            {
+                new Job("Deployment", "Deployment")
+                {
+                    Timeout = If.In("parameters.rolloutInfra", "'Test'", "'PPE'")
+                        .Value(TimeSpan.FromMinutes(60))
+                        .Else
+                        .Value(TimeSpan.FromMinutes(120)),
+                }
+            }
+        };
+    }
+
+    [Fact]
+    public Task ConditionalTimeout_IfElse_Test()
+    {
+        ConditionalTimeout_IfElsePipeline pipeline = new();
+
+        return Verify(pipeline.Serialize());
+    }
+
+    private class ConditionalTimeout_IfElseIfElsePipeline : SimpleTestPipeline
+    {
+        public override SingleStagePipeline Pipeline => new()
+        {
+            Jobs =
+            {
+                new Job("Deployment", "Deployment")
+                {
+                    Timeout = If.Equal("parameters.rolloutInfra", "'Test'")
+                        .Value(TimeSpan.FromMinutes(30))
+                        .ElseIf.Equal("parameters.rolloutInfra", "'PPE'")
+                        .Value(TimeSpan.FromMinutes(60))
+                        .Else
+                        .Value(TimeSpan.FromMinutes(120)),
+                }
+            }
+        };
+    }
+
+    [Fact]
+    public Task ConditionalTimeout_IfElseIfElse_Test()
+    {
+        ConditionalTimeout_IfElseIfElsePipeline pipeline = new();
+
+        return Verify(pipeline.Serialize());
+    }
+}

--- a/tests/Sharpliner.Tests/Verified/AzureDevOps/ConditionalScalarPropertyTests.ConditionalContinueOnError_IfElseIfElse_Test.verified.txt
+++ b/tests/Sharpliner.Tests/Verified/AzureDevOps/ConditionalScalarPropertyTests.ConditionalContinueOnError_IfElseIfElse_Test.verified.txt
@@ -1,0 +1,11 @@
+﻿jobs:
+- job: testJob
+  steps:
+  - bash: |-
+      echo hi
+    ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      continueOnError: true
+    ${{ elseif eq(variables['Build.Reason'], 'Manual') }}:
+      continueOnError: false
+    ${{ else }}:
+      continueOnError: true

--- a/tests/Sharpliner.Tests/Verified/AzureDevOps/ConditionalScalarPropertyTests.ConditionalContinueOnError_IfElse_Test.verified.txt
+++ b/tests/Sharpliner.Tests/Verified/AzureDevOps/ConditionalScalarPropertyTests.ConditionalContinueOnError_IfElse_Test.verified.txt
@@ -1,0 +1,9 @@
+﻿jobs:
+- job: testJob
+  steps:
+  - bash: |-
+      echo hi
+    ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      continueOnError: true
+    ${{ else }}:
+      continueOnError: false

--- a/tests/Sharpliner.Tests/Verified/AzureDevOps/ConditionalScalarPropertyTests.ConditionalContinueOnError_Preserves_Condition_Test.verified.txt
+++ b/tests/Sharpliner.Tests/Verified/AzureDevOps/ConditionalScalarPropertyTests.ConditionalContinueOnError_Preserves_Condition_Test.verified.txt
@@ -1,0 +1,7 @@
+jobs:
+- job: testJob
+  steps:
+  - bash: |-
+      echo hi
+    ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      continueOnError: true

--- a/tests/Sharpliner.Tests/Verified/AzureDevOps/ConditionalScalarPropertyTests.ConditionalStepTimeout_IfElseIfElse_Test.verified.txt
+++ b/tests/Sharpliner.Tests/Verified/AzureDevOps/ConditionalScalarPropertyTests.ConditionalStepTimeout_IfElseIfElse_Test.verified.txt
@@ -1,0 +1,11 @@
+﻿jobs:
+- job: testJob
+  steps:
+  - bash: |-
+      echo hi
+    ${{ if eq(parameters.rolloutInfra, 'Test') }}:
+      timeoutInMinutes: 30
+    ${{ elseif eq(parameters.rolloutInfra, 'PPE') }}:
+      timeoutInMinutes: 60
+    ${{ else }}:
+      timeoutInMinutes: 120

--- a/tests/Sharpliner.Tests/Verified/AzureDevOps/ConditionalScalarPropertyTests.ConditionalStepTimeout_IfElse_Test.verified.txt
+++ b/tests/Sharpliner.Tests/Verified/AzureDevOps/ConditionalScalarPropertyTests.ConditionalStepTimeout_IfElse_Test.verified.txt
@@ -1,0 +1,9 @@
+﻿jobs:
+- job: testJob
+  steps:
+  - bash: |-
+      echo hi
+    ${{ if in(parameters.rolloutInfra, 'Test', 'PPE') }}:
+      timeoutInMinutes: 60
+    ${{ else }}:
+      timeoutInMinutes: 120

--- a/tests/Sharpliner.Tests/Verified/AzureDevOps/ConditionalScalarPropertyTests.ConditionalStepTimeout_Preserves_Condition_Test.verified.txt
+++ b/tests/Sharpliner.Tests/Verified/AzureDevOps/ConditionalScalarPropertyTests.ConditionalStepTimeout_Preserves_Condition_Test.verified.txt
@@ -1,0 +1,7 @@
+﻿jobs:
+- job: testJob
+  steps:
+  - bash: |-
+      echo hi
+    ${{ if in(parameters.rolloutInfra, 'Test', 'PPE') }}:
+      timeoutInMinutes: 60

--- a/tests/Sharpliner.Tests/Verified/AzureDevOps/ConditionalScalarPropertyTests.ConditionalTimeout_IfElseIfElse_Test.verified.txt
+++ b/tests/Sharpliner.Tests/Verified/AzureDevOps/ConditionalScalarPropertyTests.ConditionalTimeout_IfElseIfElse_Test.verified.txt
@@ -1,0 +1,9 @@
+jobs:
+- job: Deployment
+  displayName: Deployment
+  ${{ if eq(parameters.rolloutInfra, 'Test') }}:
+    timeoutInMinutes: 30
+  ${{ elseif eq(parameters.rolloutInfra, 'PPE') }}:
+    timeoutInMinutes: 60
+  ${{ else }}:
+    timeoutInMinutes: 120

--- a/tests/Sharpliner.Tests/Verified/AzureDevOps/ConditionalScalarPropertyTests.ConditionalTimeout_IfElse_Test.verified.txt
+++ b/tests/Sharpliner.Tests/Verified/AzureDevOps/ConditionalScalarPropertyTests.ConditionalTimeout_IfElse_Test.verified.txt
@@ -1,0 +1,7 @@
+jobs:
+- job: Deployment
+  displayName: Deployment
+  ${{ if in(parameters.rolloutInfra, 'Test', 'PPE') }}:
+    timeoutInMinutes: 60
+  ${{ else }}:
+    timeoutInMinutes: 120

--- a/tests/Sharpliner.Tests/Verified/AzureDevOps/ConditionalScalarPropertyTests.ConditionalTimeout_Preserves_Condition_Test.verified.txt
+++ b/tests/Sharpliner.Tests/Verified/AzureDevOps/ConditionalScalarPropertyTests.ConditionalTimeout_Preserves_Condition_Test.verified.txt
@@ -1,0 +1,7 @@
+jobs:
+- job: Deployment
+  displayName: Deployment
+  ${{ if in(parameters.rolloutInfra, 'Test', 'PPE') }}:
+    timeoutInMinutes: 60
+  ${{ if eq(parameters.rolloutInfra, 'Prod') }}:
+    cancelTimeoutInMinutes: 5

--- a/tests/Sharpliner.Tests/Verified/AzureDevOps/ConditionalScalarPropertyTests.UnconditionalTimeout_Test.verified.txt
+++ b/tests/Sharpliner.Tests/Verified/AzureDevOps/ConditionalScalarPropertyTests.UnconditionalTimeout_Test.verified.txt
@@ -1,0 +1,5 @@
+jobs:
+- job: Deployment
+  displayName: Deployment
+  timeoutInMinutes: 60
+  cancelTimeoutInMinutes: 5


### PR DESCRIPTION
Fixes #534.

## Why

`JobBase.TimeoutInMinutes` (and `CancelTimeoutInMinutes`, `Step.Timeout`, and in fact *every* scalar `AdoExpression<T>` property — `ContinueOnError`, `Enabled`, enums, etc.) silently dropped or threw on conditional `${{ if ... }}` expressions assigned via `If.X.Value(...)`. The issue reproduced against the published 1.8.11 package and made it impossible to write things like "use a longer timeout in production".

## Approach

Conditional `AdoExpression` already worked for mapping- and list-valued properties because the condition could be expressed *inside* the value (`pool:` then `${{ if }}:` then `name: foo`). Scalars don't have that luxury — the only YAML AzDO accepts is to lift the condition *above* the property:

```yaml
${{ if eq(...) }}:
  timeoutInMinutes: 60
```

But by the time a value-position converter runs, YamlDotNet has already emitted `timeoutInMinutes:`, so the fix has to live one level up — at the property-descriptor layer. The new `ConditionalScalarTypeInspector` (a YamlDotNet `ITypeInspector` decorator) detects conditional scalar `AdoExpression<T>` properties and replaces them with N synthetic sibling descriptors, one per branch, each named `${{ if ... }}` with a one-key inner mapping `{ realName: value }`. Full `If` / `ElseIf` / `Else` chains are walked from the synthetic root.

`JobBase.TimeoutInMinutes` / `CancelTimeoutInMinutes` and `Step.Timeout` need to convert `TimeSpan -> int minutes` while preserving the conditional tree. That's done with a new `AdoExpressionConversion.ConvertScalar<TSrc,TDst>(source, convert)` helper that mirrors the tree applying the converter to each leaf.

## Tests

Added `ConditionalScalarPropertyTests` with 11 cases covering `Job.Timeout`, `Job.CancelTimeout`, `Step.Timeout`, and `Step.ContinueOnError`, each exercised with a single condition, `If`/`Else`, and `If`/`ElseIf`/`Else` chains, plus an unconditional regression case. All pass; the public-API snapshot test also passes.

## Notes for reviewers

- `AdoExpression<T>` gained an `internal static CreateEmpty()` factory so `ConvertScalar` can construct synthetic root nodes without widening the public surface.
- The inspector only fires for properties whose declared type is `AdoExpression<TScalar>` where `TScalar` is a primitive, enum, string, `TimeSpan`, or `decimal`. Mapping- and list-valued conditional properties go through the existing `IYamlConvertible.Write` path unchanged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
