### PR TITLE
Add support for npmAuthenticate@0 task

### DIFF
--- a/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
+++ b/src/Sharpliner/AzureDevOps/AzureDevOpsDefinition.cs
@@ -337,6 +337,11 @@ public abstract class AzureDevOpsDefinition
     /// </summary>
     protected static NuGetTaskBuilder NuGet { get; } = new();
 
+    /// <summary>
+    /// Creates an npm task.
+    /// </summary>
+    protected static NpmTaskBuilder Npm { get; } = new();
+
     #endregion
 
     #region Pipeline member shorthands

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/NpmTaskBuilder.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/NpmTaskBuilder.cs
@@ -10,8 +10,8 @@ public class NpmTaskBuilder
     /// file in your repository for the scope of the build. This enables npm and other npm-based tasks
     /// (e.g. <c>npm install</c>) to authenticate with private registries.
     /// </summary>
-    /// <param name="workingFile">The path to the <c>.npmrc</c> file that lists the registries you want to work with. Select the file, not the folder, such as <c>/packages/mypackage.npmrc</c>.</param>
-    /// <param name="customEndpoints">Optional comma-separated list of npm service connection names for registries outside this organization/collection.</param>
+    /// <param name="workingFile">The path to the <c>.npmrc</c> file that lists the registries you want to work with. Select the file, not the folder, such as <c>/packages/mypackage/.npmrc</c>.</param>
+    /// <param name="customEndpoints">Optional list of npm service connection names for registries outside this organization/collection.</param>
     /// <returns>An <see cref="NpmAuthenticateTask"/> instance.</returns>
     /// <example>
     /// <code lang="csharp">
@@ -31,7 +31,7 @@ public class NpmTaskBuilder
 
         if (customEndpoints is not null)
         {
-            task = task with { CustomEndpoint = customEndpoints };
+            task = task with { CustomEndpoints = customEndpoints };
         }
 
         return task;

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/NpmTaskBuilder.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/NpmTaskBuilder.cs
@@ -1,0 +1,39 @@
+namespace Sharpliner.AzureDevOps.Tasks;
+
+/// <summary>
+/// Provides methods to create various npm tasks in Azure DevOps pipelines.
+/// </summary>
+public class NpmTaskBuilder
+{
+    /// <summary>
+    /// Creates an <see cref="NpmAuthenticateTask"/> that provides npm credentials to an <c>.npmrc</c>
+    /// file in your repository for the scope of the build. This enables npm and other npm-based tasks
+    /// (e.g. <c>npm install</c>) to authenticate with private registries.
+    /// </summary>
+    /// <param name="workingFile">The path to the <c>.npmrc</c> file that lists the registries you want to work with. Select the file, not the folder, such as <c>/packages/mypackage.npmrc</c>.</param>
+    /// <param name="customEndpoints">Optional comma-separated list of npm service connection names for registries outside this organization/collection.</param>
+    /// <returns>An <see cref="NpmAuthenticateTask"/> instance.</returns>
+    /// <example>
+    /// <code lang="csharp">
+    /// Npm.Authenticate(".npmrc", ["myServiceConnection"])
+    /// </code>
+    /// <para>Generated YAML:</para>
+    /// <code lang="yaml">
+    /// - task: npmAuthenticate@0
+    ///   inputs:
+    ///     workingFile: .npmrc
+    ///     customEndpoint: myServiceConnection
+    /// </code>
+    /// </example>
+    public NpmAuthenticateTask Authenticate(string workingFile, string[]? customEndpoints = null)
+    {
+        var task = new NpmAuthenticateTask(workingFile);
+
+        if (customEndpoints is not null)
+        {
+            task = task with { CustomEndpoint = customEndpoints };
+        }
+
+        return task;
+    }
+}

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/Marketplace/NpmAuthenticateTask.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/Marketplace/NpmAuthenticateTask.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using YamlDotNet.Serialization;
 
 namespace Sharpliner.AzureDevOps.Tasks;
@@ -12,7 +14,7 @@ public record NpmAuthenticateTask : AzureDevOpsTask
     /// <summary>
     /// Initializes a new instance of the <see cref="NpmAuthenticateTask"/> class.
     /// </summary>
-    /// <param name="workingFile">The path to the <c>.npmrc</c> file that lists the registries you want to work with. Select the file, not the folder, such as <c>/packages/mypackage.npmrc</c>.</param>
+    /// <param name="workingFile">The path to the <c>.npmrc</c> file that lists the registries you want to work with. Select the file, not the folder, such as <c>/packages/mypackage/.npmrc</c>.</param>
     public NpmAuthenticateTask(string workingFile) : base("npmAuthenticate@0")
     {
         WorkingFile = workingFile;
@@ -20,7 +22,7 @@ public record NpmAuthenticateTask : AzureDevOpsTask
 
     /// <summary>
     /// Gets or sets the path to the <c>.npmrc</c> file that lists the registries you want to work with.
-    /// Select the file, not the folder, such as <c>/packages/mypackage.npmrc</c>.
+    /// Select the file, not the folder, such as <c>/packages/mypackage/.npmrc</c>.
     /// </summary>
     [YamlIgnore]
     public string WorkingFile
@@ -30,15 +32,30 @@ public record NpmAuthenticateTask : AzureDevOpsTask
     }
 
     /// <summary>
-    /// Gets or sets the comma-separated list of names of npm service connections for registries
+    /// Gets or sets the list of names of npm service connections for registries
     /// outside this organization/collection. The <c>.npmrc</c> file must contain registry entries
     /// corresponding to the service connections. If only registries in this organization/collection
     /// are needed, leave this blank. The build's credentials are used automatically.
     /// </summary>
     [YamlIgnore]
-    public string[]? CustomEndpoint
+    public string[]? CustomEndpoints
     {
-        get => GetString("customEndpoint")?.Split(',');
-        init => SetProperty("customEndpoint", string.Join(",", value!));
+        get => GetString("customEndpoint")?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        init => SetProperty("customEndpoint", ToCustomEndpointValue(value));
+    }
+
+    private static string? ToCustomEndpointValue(string[]? endpoints)
+    {
+        if (endpoints is null)
+        {
+            return null;
+        }
+
+        var normalizedEndpoints = endpoints
+            .Where(endpoint => !string.IsNullOrWhiteSpace(endpoint))
+            .Select(endpoint => endpoint.Trim())
+            .ToArray();
+
+        return normalizedEndpoints.Length == 0 ? null : string.Join(",", normalizedEndpoints);
     }
 }

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/Marketplace/NpmAuthenticateTask.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/Marketplace/NpmAuthenticateTask.cs
@@ -1,0 +1,44 @@
+using YamlDotNet.Serialization;
+
+namespace Sharpliner.AzureDevOps.Tasks;
+
+/// <summary>
+/// Represents the <see href="https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/npm-authenticate-v0">npmAuthenticate@0</see>
+/// task in Azure DevOps pipelines. The task provides npm credentials to an <c>.npmrc</c> file in your repository for the scope of the build, which
+/// enables npm to authenticate with private registries (e.g. Azure Artifacts feeds or other registries declared in the <c>.npmrc</c>).
+/// </summary>
+public record NpmAuthenticateTask : AzureDevOpsTask
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NpmAuthenticateTask"/> class.
+    /// </summary>
+    /// <param name="workingFile">The path to the <c>.npmrc</c> file that lists the registries you want to work with. Select the file, not the folder, such as <c>/packages/mypackage.npmrc</c>.</param>
+    public NpmAuthenticateTask(string workingFile) : base("npmAuthenticate@0")
+    {
+        WorkingFile = workingFile;
+    }
+
+    /// <summary>
+    /// Gets or sets the path to the <c>.npmrc</c> file that lists the registries you want to work with.
+    /// Select the file, not the folder, such as <c>/packages/mypackage.npmrc</c>.
+    /// </summary>
+    [YamlIgnore]
+    public string WorkingFile
+    {
+        get => GetString("workingFile")!;
+        init => SetProperty("workingFile", value);
+    }
+
+    /// <summary>
+    /// Gets or sets the comma-separated list of names of npm service connections for registries
+    /// outside this organization/collection. The <c>.npmrc</c> file must contain registry entries
+    /// corresponding to the service connections. If only registries in this organization/collection
+    /// are needed, leave this blank. The build's credentials are used automatically.
+    /// </summary>
+    [YamlIgnore]
+    public string[]? CustomEndpoint
+    {
+        get => GetString("customEndpoint")?.Split(',');
+        init => SetProperty("customEndpoint", string.Join(",", value!));
+    }
+}

--- a/tests/Sharpliner.Tests/AzureDevOps/Model/Tasks/TaskBuilderTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/Model/Tasks/TaskBuilderTests.cs
@@ -415,6 +415,9 @@ public class TaskBuilderTests
                     {
                         Npm.Authenticate(".npmrc"),
                         Npm.Authenticate("packages/mypackage/.npmrc", ["MyServiceConnection", "AnotherServiceConnection"]),
+                        Npm.Authenticate("empty/.npmrc", []),
+                        Npm.Authenticate("whitespace/.npmrc", [" MyServiceConnection ", "", " AnotherServiceConnection "]),
+                        new NpmAuthenticateTask("null/.npmrc") with { CustomEndpoints = null },
                     }
                 }
             }

--- a/tests/Sharpliner.Tests/AzureDevOps/Model/Tasks/TaskBuilderTests.cs
+++ b/tests/Sharpliner.Tests/AzureDevOps/Model/Tasks/TaskBuilderTests.cs
@@ -402,4 +402,30 @@ public class TaskBuilderTests
         
         return Verify(pipeline.Serialize());
     }
+
+    private class NpmTaskPipeline : TestPipeline
+    {
+        public override SingleStagePipeline Pipeline => new()
+        {
+            Jobs =
+            {
+                new Job("test")
+                {
+                    Steps =
+                    {
+                        Npm.Authenticate(".npmrc"),
+                        Npm.Authenticate("packages/mypackage/.npmrc", ["MyServiceConnection", "AnotherServiceConnection"]),
+                    }
+                }
+            }
+        };
+    }
+
+    [Fact]
+    public Task Serialize_Npm_Builders_Test()
+    {
+        NpmTaskPipeline pipeline = new();
+
+        return Verify(pipeline.Serialize());
+    }
 }

--- a/tests/Sharpliner.Tests/PublicApiExport.txt.verified.txt
+++ b/tests/Sharpliner.Tests/PublicApiExport.txt.verified.txt
@@ -96,6 +96,7 @@ namespace Sharpliner.AzureDevOps
         protected static Sharpliner.AzureDevOps.InlineCondition IsNotPullRequest { get; }
         protected static Sharpliner.AzureDevOps.InlineCondition IsPullRequest { get; }
         protected static Sharpliner.AzureDevOps.DependsOn NoDependsOn { get; }
+        protected static Sharpliner.AzureDevOps.Tasks.NpmTaskBuilder Npm { get; }
         protected static Sharpliner.AzureDevOps.Tasks.NuGetTaskBuilder NuGet { get; }
         protected static Sharpliner.AzureDevOps.Tasks.PowershellTaskBuilder Powershell { get; }
         protected static Sharpliner.AzureDevOps.Tasks.PublishTaskBuilder Publish { get; }
@@ -1928,6 +1929,19 @@ namespace Sharpliner.AzureDevOps.Tasks
         public NoneDownloadTask() { }
         [YamlDotNet.Serialization.YamlMember(Order=1)]
         public string Download { get; }
+    }
+    public class NpmAuthenticateTask : Sharpliner.AzureDevOps.Tasks.AzureDevOpsTask, System.IEquatable<Sharpliner.AzureDevOps.Tasks.NpmAuthenticateTask>
+    {
+        public NpmAuthenticateTask(string workingFile) { }
+        [YamlDotNet.Serialization.YamlIgnore]
+        public string[]? CustomEndpoint { get; init; }
+        [YamlDotNet.Serialization.YamlIgnore]
+        public string WorkingFile { get; init; }
+    }
+    public class NpmTaskBuilder
+    {
+        public NpmTaskBuilder() { }
+        public Sharpliner.AzureDevOps.Tasks.NpmAuthenticateTask Authenticate(string workingFile, string[]? customEndpoints = null) { }
     }
     public class NuGetAuthenticateTask : Sharpliner.AzureDevOps.Tasks.AzureDevOpsTask, System.IEquatable<Sharpliner.AzureDevOps.Tasks.NuGetAuthenticateTask>
     {

--- a/tests/Sharpliner.Tests/PublicApiExport.txt.verified.txt
+++ b/tests/Sharpliner.Tests/PublicApiExport.txt.verified.txt
@@ -1934,7 +1934,7 @@ namespace Sharpliner.AzureDevOps.Tasks
     {
         public NpmAuthenticateTask(string workingFile) { }
         [YamlDotNet.Serialization.YamlIgnore]
-        public string[]? CustomEndpoint { get; init; }
+        public string[]? CustomEndpoints { get; init; }
         [YamlDotNet.Serialization.YamlIgnore]
         public string WorkingFile { get; init; }
     }

--- a/tests/Sharpliner.Tests/Verified/AzureDevOps/TaskBuilderTests.Serialize_Npm_Builders_Test.verified.txt
+++ b/tests/Sharpliner.Tests/Verified/AzureDevOps/TaskBuilderTests.Serialize_Npm_Builders_Test.verified.txt
@@ -1,0 +1,11 @@
+﻿jobs:
+- job: test
+  steps:
+  - task: npmAuthenticate@0
+    inputs:
+      workingFile: .npmrc
+
+  - task: npmAuthenticate@0
+    inputs:
+      workingFile: packages/mypackage/.npmrc
+      customEndpoint: MyServiceConnection,AnotherServiceConnection

--- a/tests/Sharpliner.Tests/Verified/AzureDevOps/TaskBuilderTests.Serialize_Npm_Builders_Test.verified.txt
+++ b/tests/Sharpliner.Tests/Verified/AzureDevOps/TaskBuilderTests.Serialize_Npm_Builders_Test.verified.txt
@@ -1,4 +1,4 @@
-﻿jobs:
+jobs:
 - job: test
   steps:
   - task: npmAuthenticate@0
@@ -9,3 +9,16 @@
     inputs:
       workingFile: packages/mypackage/.npmrc
       customEndpoint: MyServiceConnection,AnotherServiceConnection
+
+  - task: npmAuthenticate@0
+    inputs:
+      workingFile: empty/.npmrc
+
+  - task: npmAuthenticate@0
+    inputs:
+      workingFile: whitespace/.npmrc
+      customEndpoint: MyServiceConnection,AnotherServiceConnection
+
+  - task: npmAuthenticate@0
+    inputs:
+      workingFile: null/.npmrc


### PR DESCRIPTION
Adds typed support for the Azure DevOps npmAuthenticate@0 task, including builder/API wiring, serialization coverage, and the public API snapshot update.