### PR TITLE
docs: add XML doc code examples to task builders

### DIFF
--- a/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/AzureCliTaskBuilder.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/AzureCliTaskBuilder.cs
@@ -43,7 +43,7 @@ public class AzureCliTaskBuilder : TaskBuilderBase
 
     /// <summary>
     /// Creates an Azure CLI task where the contents come from a file.
-    /// The contents are inlined in the YAML as contrary to File method where the file name is just referenced.
+    /// The contents are inlined in the YAML as opposed to the File method where the file name is just referenced.
     /// <para>For example: assuming the file <c>scripts/deploy.sh</c> contains <c>az group create --name myRG --location eastus</c>:</para>
     /// <code lang="csharp">
     /// Steps =
@@ -99,7 +99,7 @@ public class AzureCliTaskBuilder : TaskBuilderBase
     /// <param name="scriptPath">Path to the script</param>
     /// <param name="displayName">Name of the build step</param>
     /// <returns>A new instance of <see cref="AzureCliFileTask"/> with the file path</returns>
-    public AzureCliFileTask File(string azureSubscription, AdoExpression<ScriptType> scriptType, string scriptPath, AdoExpression<string>? displayName = null)=> new(azureSubscription, scriptType,scriptPath)
+    public AzureCliFileTask File(string azureSubscription, AdoExpression<ScriptType> scriptType, string scriptPath, AdoExpression<string>? displayName = null) => new(azureSubscription, scriptType, scriptPath)
     {
         DisplayName = displayName!,
         ScriptPath = scriptPath,

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/AzureCliTaskBuilder.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/AzureCliTaskBuilder.cs
@@ -11,6 +11,24 @@ public class AzureCliTaskBuilder : TaskBuilderBase
 {
     /// <summary>
     /// Creates an Azure CLI task where the contents come from an embedded resource.
+    /// <para>For example: assuming the embedded resource file <c>deploy.sh</c> contains <c>az group create --name myRG --location eastus</c>:</para>
+    /// <code lang="csharp">
+    /// Steps =
+    /// {
+    ///     AzureCli.FromResourceFile("myServiceConnection", ScriptType.Bash, "deploy.sh", "Deploy resources")
+    /// }
+    /// </code>
+    /// Will generate:
+    /// <code lang="yaml">
+    /// - task: AzureCLI@2
+    ///   displayName: Deploy resources
+    ///   inputs:
+    ///     azureSubscription: myServiceConnection
+    ///     scriptType: bash
+    ///     scriptLocation: inlineScript
+    ///     inlineScript: |
+    ///       az group create --name myRG --location eastus
+    /// </code>
     /// </summary>
     /// <param name="azureSubscription">Azure Resource Manager service connection for the deployment.</param>
     /// <param name="scriptType">Type of script.</param>
@@ -26,6 +44,24 @@ public class AzureCliTaskBuilder : TaskBuilderBase
     /// <summary>
     /// Creates an Azure CLI task where the contents come from a file.
     /// The contents are inlined in the YAML as contrary to File method where the file name is just referenced.
+    /// <para>For example: assuming the file <c>scripts/deploy.sh</c> contains <c>az group create --name myRG --location eastus</c>:</para>
+    /// <code lang="csharp">
+    /// Steps =
+    /// {
+    ///     AzureCli.FromFile("myServiceConnection", ScriptType.Bash, "scripts/deploy.sh", "Deploy resources")
+    /// }
+    /// </code>
+    /// Will generate:
+    /// <code lang="yaml">
+    /// - task: AzureCLI@2
+    ///   displayName: Deploy resources
+    ///   inputs:
+    ///     azureSubscription: myServiceConnection
+    ///     scriptType: bash
+    ///     scriptLocation: inlineScript
+    ///     inlineScript: |
+    ///       az group create --name myRG --location eastus
+    /// </code>
     /// </summary>
     /// <param name="azureSubscription">Azure Resource Manager service connection for the deployment.</param>
     /// <param name="scriptType">Type of script.</param>
@@ -40,13 +76,30 @@ public class AzureCliTaskBuilder : TaskBuilderBase
 
     /// <summary>
     /// Creates an Azure CLI task referencing a file (contents are not inlined in the YAML).
+    /// <para>For example:</para>
+    /// <code lang="csharp">
+    /// Steps =
+    /// {
+    ///     AzureCli.File("myServiceConnection", ScriptType.Bash, "scripts/deploy.sh", "Deploy resources")
+    /// }
+    /// </code>
+    /// Will generate:
+    /// <code lang="yaml">
+    /// - task: AzureCLI@2
+    ///   displayName: Deploy resources
+    ///   inputs:
+    ///     azureSubscription: myServiceConnection
+    ///     scriptType: bash
+    ///     scriptLocation: scriptPath
+    ///     scriptPath: scripts/deploy.sh
+    /// </code>
     /// </summary>
     /// <param name="azureSubscription">Azure Resource Manager service connection for the deployment.</param>
     /// <param name="scriptType">Type of script.</param>
     /// <param name="scriptPath">Path to the script</param>
     /// <param name="displayName">Name of the build step</param>
     /// <returns>A new instance of <see cref="AzureCliFileTask"/> with the file path</returns>
-    public AzureCliFileTask File(string azureSubscription, AdoExpression<ScriptType> scriptType, string scriptPath, AdoExpression<string>? displayName = null) => new(azureSubscription, scriptType,scriptPath)
+    public AzureCliFileTask File(string azureSubscription, AdoExpression<ScriptType> scriptType, string scriptPath, AdoExpression<string>? displayName = null)=> new(azureSubscription, scriptType,scriptPath)
     {
         DisplayName = displayName!,
         ScriptPath = scriptPath,
@@ -54,6 +107,31 @@ public class AzureCliTaskBuilder : TaskBuilderBase
 
     /// <summary>
     /// Creates an Azure CLI task with given contents.
+    /// <para>For example:</para>
+    /// <code lang="csharp">
+    /// Steps =
+    /// {
+    ///     AzureCli.Inline(
+    ///         "myServiceConnection",
+    ///         ScriptType.Bash,
+    ///         "Deploy resources",
+    ///         "az group create --name myRG --location eastus",
+    ///         "az deployment group create --resource-group myRG --template-file azuredeploy.json"
+    ///     )
+    /// }
+    /// </code>
+    /// Will generate:
+    /// <code lang="yaml">
+    /// - task: AzureCLI@2
+    ///   displayName: Deploy resources
+    ///   inputs:
+    ///     azureSubscription: myServiceConnection
+    ///     scriptType: bash
+    ///     scriptLocation: inlineScript
+    ///     inlineScript: |
+    ///       az group create --name myRG --location eastus
+    ///       az deployment group create --resource-group myRG --template-file azuredeploy.json
+    /// </code>
     /// </summary>
     /// <param name="azureSubscription">Azure Resource Manager service connection for the deployment.</param>
     /// <param name="scriptType">Type of script.</param>

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/DotNetTaskBuilder.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/DotNetTaskBuilder.cs
@@ -12,12 +12,46 @@ public class DotNetTaskBuilder
     }
 
     /// <summary>
-    /// Creates the <c>install</c> command version of the DotNetCoreCLI task.
+    /// <para>
+    /// Gets a <see cref="DotNetInstallBuilder"/> instance to create <c>UseDotNet</c> tasks
+    /// that install the .NET SDK or runtime.
+    /// </para>
+    /// For example:
+    /// <code lang="csharp">
+    /// Steps =
+    /// {
+    ///     DotNet.Install.Sdk("8.0.x")
+    /// }
+    /// </code>
+    /// Will generate:
+    /// <code lang="yaml">
+    /// - task: UseDotNet@2
+    ///   inputs:
+    ///     packageType: sdk
+    ///     version: 8.0.x
+    /// </code>
     /// </summary>
     public DotNetInstallBuilder Install => new();
 
     /// <summary>
-    /// Creates the <c>restore</c> command version of the DotNetCoreCLI task.
+    /// <para>
+    /// Gets a <see cref="DotNetRestoreBuilder"/> instance to create <c>dotnet restore</c> tasks
+    /// using the DotNetCoreCLI task.
+    /// </para>
+    /// For example:
+    /// <code lang="csharp">
+    /// Steps =
+    /// {
+    ///     DotNet.Restore.Projects("src/*.csproj")
+    /// }
+    /// </code>
+    /// Will generate:
+    /// <code lang="yaml">
+    /// - task: DotNetCoreCLI@2
+    ///   inputs:
+    ///     command: restore
+    ///     projects: src/*.csproj
+    /// </code>
     /// </summary>
     public DotNetRestoreBuilder Restore => new();
 

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/DownloadTaskBuilder.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/DownloadTaskBuilder.cs
@@ -215,6 +215,19 @@ public class DownloadTaskBuilder
 
     /// <summary>
     /// Creates a download task that an artifact from a pipeline resource.
+    /// <para>For example:</para>
+    /// <code lang="csharp">
+    /// Steps =
+    /// {
+    ///     Download.FromPipelineResource("myPipelineResource", "MyArtifact", ["**/*.dll"])
+    /// }
+    /// </code>
+    /// Will generate:
+    /// <code lang="yaml">
+    /// - download: myPipelineResource
+    ///   artifact: MyArtifact
+    ///   patterns: '**/*.dll'
+    /// </code>
     /// </summary>
     /// <param name="resourceName">Alredy defined pipeline resource</param>
     /// <param name="artifact">The name of the artifact to download. If left empty, all artifacts associated to the pipeline run will be downloaded.</param>

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/DownloadTaskBuilder.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/DownloadTaskBuilder.cs
@@ -214,7 +214,7 @@ public class DownloadTaskBuilder
         };
 
     /// <summary>
-    /// Creates a download task that an artifact from a pipeline resource.
+    /// Creates a download task that downloads an artifact from a pipeline resource.
     /// <para>For example:</para>
     /// <code lang="csharp">
     /// Steps =
@@ -229,7 +229,7 @@ public class DownloadTaskBuilder
     ///   patterns: '**/*.dll'
     /// </code>
     /// </summary>
-    /// <param name="resourceName">Alredy defined pipeline resource</param>
+    /// <param name="resourceName">Already defined pipeline resource</param>
     /// <param name="artifact">The name of the artifact to download. If left empty, all artifacts associated to the pipeline run will be downloaded.</param>
     /// <param name="patterns">
     /// One or more file matching patterns that limit which files get downloaded.

--- a/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/NuGetTaskBuilder.cs
+++ b/src/Sharpliner/AzureDevOps/Model/Tasks/Builders/NuGetTaskBuilder.cs
@@ -159,7 +159,7 @@ public class NuGetRestoreBuilder
     /// Creates a NuGetRestoreCommandTask to restore packages from a NuGet.config file.
     /// </para>
     /// <code lang="csharp">
-    /// NuGet.Restore.FromNuGetConfig("path/to/NuGet.config");
+    /// NuGet.Restore.FromNuGetConfig("path/to/NuGet.config") with
     /// {
     ///   RestoreSolution = "path/to/solution.sln"
     /// }
@@ -240,6 +240,23 @@ public class NuGetPackBuilder
 {
     /// <summary>
     /// Creates a task to pack NuGet packages without versioning.
+    /// <para>For example:</para>
+    /// <code lang="csharp">
+    /// NuGet.Pack.WithoutPackageVersioning with
+    /// {
+    ///     PackagesToPack = "**/*.csproj",
+    ///     PackDestination = "$(Build.ArtifactStagingDirectory)"
+    /// }
+    /// </code>
+    /// Generated YAML:
+    /// <code lang="yaml">
+    /// - task: NuGetCommand@2
+    ///   inputs:
+    ///     command: pack
+    ///     versioningScheme: off
+    ///     packagesToPack: '**/*.csproj'
+    ///     packDestination: $(Build.ArtifactStagingDirectory)
+    /// </code>
     /// </summary>
     public NuGetPackCommandTaskOff WithoutPackageVersioning => new();
 
@@ -247,6 +264,19 @@ public class NuGetPackBuilder
     /// <para>
     /// Creates a task to pack NuGet packages with the version set by a prerelease number.
     /// </para>
+    /// <code lang="csharp">
+    /// NuGet.Pack.ByPrereleaseNumber("1", "2", "3")
+    /// </code>
+    /// Generated YAML:
+    /// <code lang="yaml">
+    /// - task: NuGetCommand@2
+    ///   inputs:
+    ///     command: pack
+    ///     versioningScheme: byPrereleaseNumber
+    ///     majorVersion: '1'
+    ///     minorVersion: '2'
+    ///     patchVersion: '3'
+    /// </code>
     /// </summary>
     /// <param name="majorVersion">The <c>X</c> in version <see href="http://semver.org/spec/v1.0.0.html">X.Y.Z</see>.</param>
     /// <param name="minorVersion">The <c>Y</c> in version <see href="http://semver.org/spec/v1.0.0.html">X.Y.Z</see>.</param>
@@ -260,6 +290,17 @@ public class NuGetPackBuilder
     /// </para>
     /// The version will be set to the value of the environment variable that has the name specified by the versionEnvVar parameter, e.g. <c>MyVersion</c> (no $, just the environment variable name). 
     /// Make sure the environment variable is set to a proper SemVer, such as <c>1.2.3</c> or <c>1.2.3-beta1</c>.
+    /// <code lang="csharp">
+    /// NuGet.Pack.ByEnvVar("MY_PACKAGE_VERSION")
+    /// </code>
+    /// Generated YAML:
+    /// <code lang="yaml">
+    /// - task: NuGetCommand@2
+    ///   inputs:
+    ///     command: pack
+    ///     versioningScheme: byEnvVar
+    ///     versionEnvVar: MY_PACKAGE_VERSION
+    /// </code>
     /// </summary>
     /// <param name="versionEnvVar">The name of the environment variable that contains the version.</param>
     /// <returns>A new instance of <see cref="NuGetPackCommandTaskByEnvVar"/>.</returns>
@@ -274,6 +315,20 @@ public class NuGetPackBuilder
     /// Ensure that the build number being used contains a proper SemVer, such as <c>1.0.$(Rev:r)</c>. 
     /// The task will extract the dotted version, <c>1.2.3.4</c>, from the build number string, and use only that portion. 
     /// The rest of the string will be dropped.
+    /// <code lang="csharp">
+    /// NuGet.Pack.ByBuildNumber with
+    /// {
+    ///     PackagesToPack = "**/*.csproj"
+    /// }
+    /// </code>
+    /// Generated YAML:
+    /// <code lang="yaml">
+    /// - task: NuGetCommand@2
+    ///   inputs:
+    ///     command: pack
+    ///     versioningScheme: byBuildNumber
+    ///     packagesToPack: '**/*.csproj'
+    /// </code>
     /// </summary>
     public NuGetPackCommandTaskByBuildNumber ByBuildNumber => new();
 }


### PR DESCRIPTION
## Summary

Adds C#/YAML code examples to the XML documentation comments for several task builder methods/properties, making IntelliSense more helpful to users.

### Changes

- **AzureCliTaskBuilder**: Added examples for `FromResourceFile`, `FromFile`, `File`, and `Inline` methods
- **DotNetTaskBuilder**: Added examples for `Install` and `Restore` properties
- **DownloadTaskBuilder**: Added example for `FromPipelineResource` method
- **NuGetTaskBuilder**: Added examples for `Pack.WithoutPackageVersioning`, `Pack.ByPrereleaseNumber`, `Pack.ByEnvVar`, `Pack.ByBuildNumber`; fixed `Restore.FromNuGetConfig` code example syntax

Each example shows the C# usage and the corresponding generated YAML output.